### PR TITLE
feat(training-service): add orchestrator foundation context layer

### DIFF
--- a/ktrdr/api/endpoints/training.py
+++ b/ktrdr/api/endpoints/training.py
@@ -11,9 +11,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
 
 from ktrdr import get_logger
-from ktrdr.api.services.operations_service import (
-    get_operations_service,
-)
 from ktrdr.api.services.training_service import TrainingService
 from ktrdr.errors import DataError, ValidationError
 
@@ -169,9 +166,7 @@ async def get_training_service() -> TrainingService:
     """Get training service instance (singleton)."""
     global _training_service
     if _training_service is None:
-        # Pass the global OperationsService singleton to avoid creating separate instances
-        operations_service = get_operations_service()
-        _training_service = TrainingService(operations_service=operations_service)
+        _training_service = TrainingService()
     return _training_service
 
 

--- a/ktrdr/api/services/training/__init__.py
+++ b/ktrdr/api/services/training/__init__.py
@@ -1,0 +1,10 @@
+"""Training service helpers package."""
+
+from .context import TrainingOperationContext, build_training_context
+from .progress_bridge import TrainingProgressBridge
+
+__all__ = [
+    "TrainingOperationContext",
+    "TrainingProgressBridge",
+    "build_training_context",
+]

--- a/ktrdr/api/services/training/context.py
+++ b/ktrdr/api/services/training/context.py
@@ -1,0 +1,244 @@
+"""Context helpers for orchestrated training operations."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ktrdr.api.endpoints.strategies import _validate_strategy_config
+from ktrdr.api.models.operations import OperationMetadata
+from ktrdr.errors import ValidationError
+
+# Default locations where strategy YAML files may live (docker + host paths)
+DEFAULT_STRATEGY_PATHS: tuple[Path, ...] = (
+    Path("/app/strategies"),
+    Path("strategies"),
+)
+
+
+@dataclass(slots=True)
+class TrainingOperationContext:
+    """Immutable snapshot describing a managed training operation."""
+
+    operation_id: str | None
+    strategy_name: str
+    strategy_path: Path
+    strategy_config: dict[str, Any]
+    symbols: list[str]
+    timeframes: list[str]
+    start_date: str | None
+    end_date: str | None
+    training_config: dict[str, Any]
+    analytics_enabled: bool
+    use_host_service: bool
+    training_mode: str
+    total_epochs: int
+    total_batches: int | None
+    metadata: OperationMetadata
+    session_id: str | None = None
+
+    @property
+    def total_steps(self) -> int:
+        """Expose the number of coarse progress steps (epochs)."""
+        return max(self.total_epochs, 1)
+
+
+def build_training_context(
+    *,
+    operation_id: str | None = None,
+    strategy_name: str,
+    symbols: list[str],
+    timeframes: list[str],
+    start_date: str | None,
+    end_date: str | None,
+    detailed_analytics: bool,
+    use_host_service: bool,
+    strategy_search_paths: Iterable[Path] | None = None,
+) -> TrainingOperationContext:
+    """Construct a ``TrainingOperationContext`` from user input and config files."""
+
+    strategy_path = _resolve_strategy_path(strategy_name, strategy_search_paths)
+    strategy_config = _load_strategy_config(strategy_path)
+    _validate_strategy(strategy_config, strategy_name)
+
+    if detailed_analytics:
+        _apply_detailed_analytics(strategy_config)
+
+    model_config = strategy_config.get("model", {}) or {}
+    training_config = dict(model_config.get("training", {}) or {})
+    total_epochs = _extract_total_epochs(training_config)
+    total_batches = _extract_total_batches(training_config, total_epochs)
+    model_type = model_config.get("type", "mlp")
+
+    metadata = _build_operation_metadata(
+        strategy_name=strategy_name,
+        strategy_path=strategy_path,
+        symbols=symbols,
+        timeframes=timeframes,
+        start_date=start_date,
+        end_date=end_date,
+        model_type=model_type,
+        total_epochs=total_epochs,
+        use_host_service=use_host_service,
+        analytics_enabled=detailed_analytics,
+        total_batches=total_batches,
+    )
+
+    context = TrainingOperationContext(
+        operation_id=operation_id,
+        strategy_name=strategy_name,
+        strategy_path=strategy_path,
+        strategy_config=strategy_config,
+        symbols=list(symbols),
+        timeframes=list(timeframes),
+        start_date=start_date,
+        end_date=end_date,
+        training_config=training_config,
+        analytics_enabled=detailed_analytics,
+        use_host_service=use_host_service,
+        training_mode="host_service" if use_host_service else "local",
+        total_epochs=total_epochs,
+        total_batches=total_batches,
+        metadata=metadata,
+    )
+    return context
+
+
+def _resolve_strategy_path(
+    strategy_name: str, strategy_search_paths: Iterable[Path] | None
+) -> Path:
+    """Locate the strategy YAML file, checking docker + host paths."""
+
+    candidate_paths: list[Path] = []
+
+    search_roots = (
+        list(strategy_search_paths)
+        if strategy_search_paths is not None
+        else list(DEFAULT_STRATEGY_PATHS)
+    )
+
+    for root in search_roots:
+        path = Path(root)
+        if path.is_dir():
+            candidate = path / f"{strategy_name}.yaml"
+        else:
+            candidate = path
+        candidate_paths.append(candidate)
+        if candidate.exists():
+            return candidate
+
+    searched = ", ".join(str(p) for p in candidate_paths)
+    raise ValidationError(
+        f"Strategy file not found: {strategy_name}.yaml (searched: {searched})"
+    )
+
+
+def _load_strategy_config(strategy_path: Path) -> dict[str, Any]:
+    """Load YAML strategy configuration from disk."""
+    try:
+        with open(strategy_path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive guard
+        raise ValidationError(f"Failed to parse strategy YAML: {exc}") from exc
+    except OSError as exc:  # pragma: no cover - filesystem errors surfaced
+        raise ValidationError(f"Unable to read strategy file: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValidationError("Strategy configuration must be a mapping")
+
+    return data
+
+
+def _validate_strategy(strategy_config: dict[str, Any], strategy_name: str) -> None:
+    """Run shared strategy validation and raise on errors."""
+    issues = _validate_strategy_config(strategy_config, strategy_name)
+    error_messages = [
+        f"{issue.category}: {issue.message}"
+        for issue in issues
+        if getattr(issue, "severity", "").lower() == "error"
+    ]
+
+    if error_messages:
+        formatted = "\n".join(error_messages)
+        raise ValidationError(f"Strategy validation failed:\n{formatted}")
+
+
+def _apply_detailed_analytics(strategy_config: dict[str, Any]) -> None:
+    """Mirror legacy behaviour for enabling detailed analytics."""
+    training_section = strategy_config.setdefault("training", {})
+    training_section["detailed_analytics"] = True
+    training_section["save_intermediate_models"] = True
+    training_section["track_gradients"] = True
+
+
+def _extract_total_epochs(training_config: dict[str, Any]) -> int:
+    """Read total epochs, defaulting to 1 for unknown configs."""
+    try:
+        epochs = int(training_config.get("epochs", 1))
+    except (TypeError, ValueError):
+        epochs = 1
+    return max(epochs, 1)
+
+
+def _extract_total_batches(
+    training_config: dict[str, Any], total_epochs: int
+) -> int | None:
+    """Derive total batches when configuration provides enough detail."""
+    total_batches = training_config.get("total_batches")
+    if isinstance(total_batches, int) and total_batches > 0:
+        return total_batches
+
+    per_epoch = training_config.get("batches_per_epoch")
+    if isinstance(per_epoch, int) and per_epoch > 0 and total_epochs > 0:
+        return per_epoch * total_epochs
+
+    return None
+
+
+def _build_operation_metadata(
+    *,
+    strategy_name: str,
+    strategy_path: Path,
+    symbols: list[str],
+    timeframes: list[str],
+    start_date: str | None,
+    end_date: str | None,
+    model_type: str,
+    total_epochs: int,
+    use_host_service: bool,
+    analytics_enabled: bool,
+    total_batches: int | None,
+) -> OperationMetadata:
+    """Assemble the OperationMetadata payload for orchestrated training."""
+
+    start_dt = datetime.fromisoformat(start_date) if start_date else None
+    end_dt = datetime.fromisoformat(end_date) if end_date else None
+
+    parameters: dict[str, Any] = {
+        "strategy_name": strategy_name,
+        "strategy_path": str(strategy_path),
+        "training_type": model_type,
+        "symbols": list(symbols),
+        "timeframes": list(timeframes),
+        "epochs": total_epochs,
+        "use_host_service": use_host_service,
+        "analytics_enabled": analytics_enabled,
+        "training_mode": "host_service" if use_host_service else "local",
+    }
+    if total_batches is not None:
+        parameters["total_batches"] = total_batches
+
+    metadata = OperationMetadata(
+        symbol=symbols[0] if symbols else "MULTI",
+        timeframe=timeframes[0] if timeframes else None,
+        mode="training",
+        start_date=start_dt,
+        end_date=end_dt,
+        parameters=parameters,
+    )
+    return metadata

--- a/ktrdr/api/services/training/progress_bridge.py
+++ b/ktrdr/api/services/training/progress_bridge.py
@@ -1,0 +1,127 @@
+"""Stub progress bridge for orchestrated training operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ktrdr import get_logger
+from ktrdr.async_infrastructure.progress import GenericProgressManager
+
+logger = get_logger(__name__)
+
+
+class TrainingProgressBridge:
+    """Placeholder progress bridge wiring training events to the orchestrator."""
+
+    def __init__(
+        self,
+        *,
+        progress_manager: GenericProgressManager | None = None,
+        update_progress_callback: Callable[..., None] | None = None,
+        total_steps: int = 1,
+    ) -> None:
+        if progress_manager is None and update_progress_callback is None:
+            raise ValueError(
+                "progress_manager or update_progress_callback must be provided"
+            )
+
+        self._progress_manager = progress_manager
+        self._update_callback = update_progress_callback
+        self._total_steps = max(total_steps, 1)
+
+    def on_phase(self, phase_name: str) -> None:
+        """Emit a coarse progress update for a named phase."""
+        logger.debug("[TrainingProgressBridge] phase=%s", phase_name)
+        self._emit_progress(
+            step=0,
+            message=f"Phase: {phase_name}",
+            context={"phase": phase_name},
+        )
+
+    def on_epoch(
+        self,
+        epoch: int,
+        total_epochs: int | None = None,
+        metrics: dict[str, Any] | None = None,
+    ) -> None:
+        """Stub epoch update (no fine-grained percentage yet)."""
+        message = f"Epoch {epoch}"
+        context: dict[str, Any] = {"phase": "epoch", "epoch": epoch}
+        if total_epochs is not None:
+            message = f"Epoch {epoch}/{total_epochs}"
+            context["total_epochs"] = total_epochs
+        if metrics:
+            context["metrics"] = metrics
+
+        logger.debug("[TrainingProgressBridge] epoch=%s total=%s", epoch, total_epochs)
+        self._emit_progress(step=0, message=message, context=context)
+
+    def on_batch(
+        self,
+        epoch: int,
+        batch: int,
+        total_batches: int | None = None,
+        metrics: dict[str, Any] | None = None,
+    ) -> None:
+        """Batch updates are ignored in the stub to avoid noisy progress spam."""
+        logger.debug(
+            "[TrainingProgressBridge] batch update ignored (epoch=%s batch=%s total=%s)",
+            epoch,
+            batch,
+            total_batches,
+        )
+        # Intentional no-op for the stub implementation
+
+    def on_remote_snapshot(self, snapshot: dict[str, Any]) -> None:
+        """Handle remote host-service snapshots (stubbed)."""
+        logger.debug("[TrainingProgressBridge] remote snapshot=%s", snapshot)
+        self._emit_progress(
+            step=0,
+            message="Remote progress update",
+            context={"phase": "remote_snapshot", "snapshot": snapshot},
+        )
+
+    def on_complete(self, message: str = "Training complete") -> None:
+        """Mark progress as complete with a single 100% update."""
+        logger.debug("[TrainingProgressBridge] completing training")
+        self._emit_progress(
+            step=self._total_steps,
+            message=message,
+            context={"phase": "completed"},
+        )
+
+    def _emit_progress(
+        self,
+        *,
+        step: int,
+        message: str,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        """Send progress to whichever sink the bridge was configured with."""
+        if context is None:
+            context = {}
+
+        if self._progress_manager is not None:
+            self._progress_manager.update_progress(
+                step=max(step, 0),
+                message=message,
+                items_processed=min(max(step, 0), self._total_steps),
+                context=context,
+            )
+
+        if self._update_callback is not None:
+            try:
+                self._update_callback(
+                    step=max(step, 0),
+                    message=message,
+                    items_processed=min(max(step, 0), self._total_steps),
+                    **context,
+                )
+            except TypeError:
+                # Fallback if consumer does not accept keyword context payload
+                self._update_callback(
+                    step=max(step, 0),
+                    message=message,
+                    items_processed=min(max(step, 0), self._total_steps),
+                )

--- a/ktrdr/async_infrastructure/service_orchestrator.py
+++ b/ktrdr/async_infrastructure/service_orchestrator.py
@@ -7,6 +7,7 @@ patterns across all service managers (Data, Training, Backtesting, etc.).
 """
 
 import asyncio
+import inspect
 import os
 import threading
 import time
@@ -944,6 +945,10 @@ class ServiceOrchestrator(ABC, Generic[T]):
 
         operations_service = get_operations_service()
 
+        operation_kwargs = dict(kwargs)
+        metadata_input = operation_kwargs.pop("metadata", None)
+        total_steps = operation_kwargs.pop("total_steps", 100)
+
         # Convert string operation type to enum
         try:
             op_type = OperationType(operation_type.lower())
@@ -951,18 +956,40 @@ class ServiceOrchestrator(ABC, Generic[T]):
             op_type = OperationType.DATA_LOAD  # Default fallback
 
         # Create operation metadata with all required fields
-        metadata = OperationMetadata(
-            symbol="N/A",
-            timeframe="N/A",
-            mode="N/A",
-            start_date=None,
-            end_date=None,
-            parameters={
-                "operation_name": operation_name,
-                "service_name": self._get_service_name(),
-                **kwargs.get("metadata", {}),
-            },
-        )
+        metadata_base_params = {
+            "operation_name": operation_name,
+            "service_name": self._get_service_name(),
+        }
+
+        def _build_metadata_from_dict(data):
+            metadata_dict = {
+                "symbol": "N/A",
+                "timeframe": "N/A",
+                "mode": "N/A",
+                "start_date": None,
+                "end_date": None,
+                "parameters": dict(metadata_base_params),
+            }
+            if isinstance(data, dict):
+                extra = dict(data)
+                parameters_override = extra.pop("parameters", {})
+                metadata_dict["parameters"].update(parameters_override)
+                for field in ("symbol", "timeframe", "mode", "start_date", "end_date"):
+                    if field in extra:
+                        metadata_dict[field] = extra[field]
+            return OperationMetadata(**metadata_dict)
+
+        if isinstance(metadata_input, OperationMetadata):
+            metadata = metadata_input.model_copy(
+                update={
+                    "parameters": {
+                        **metadata_input.parameters,
+                        **metadata_base_params,
+                    }
+                }
+            )
+        else:
+            metadata = _build_metadata_from_dict(metadata_input)
 
         # Create operation via operations service
         operation_info = await operations_service.create_operation(
@@ -1031,7 +1058,7 @@ class ServiceOrchestrator(ABC, Generic[T]):
                 # Start progress tracking
                 operation_progress.start_operation(
                     operation_id=operation_name,
-                    total_steps=kwargs.get("total_steps", 100),
+                    total_steps=total_steps,
                     context={
                         "operation": operation_name,
                         "service": self._get_service_name(),
@@ -1042,9 +1069,15 @@ class ServiceOrchestrator(ABC, Generic[T]):
                 logger.info(
                     f"🚀 STARTING OPERATION EXECUTION: Thread {threading.current_thread().ident}, Operation {operation_id}"
                 )
-                result = await operation_func(
-                    *args, **{k: v for k, v in kwargs.items() if k != "metadata"}
+                operation_call_kwargs = dict(operation_kwargs)
+                signature = inspect.signature(operation_func)
+                accepts_operation_id = "operation_id" in signature.parameters or any(
+                    param.kind == inspect.Parameter.VAR_KEYWORD
+                    for param in signature.parameters.values()
                 )
+                if accepts_operation_id:
+                    operation_call_kwargs["operation_id"] = operation_id
+                result = await operation_func(*args, **operation_call_kwargs)
                 logger.info(
                     f"✅ OPERATION EXECUTION COMPLETED: Thread {threading.current_thread().ident}, Operation {operation_id}"
                 )
@@ -1113,6 +1146,9 @@ class ServiceOrchestrator(ABC, Generic[T]):
         """
         logger.debug(f"Starting sync operation: {operation_name}")
 
+        operation_kwargs = dict(kwargs)
+        total_steps = operation_kwargs.pop("total_steps", 100)
+
         # Create a temporary operation ID for progress/cancellation tracking
         temp_operation_id = f"sync_{operation_name}_{id(operation_func)}"
 
@@ -1140,7 +1176,7 @@ class ServiceOrchestrator(ABC, Generic[T]):
                 # Start progress tracking
                 operation_progress.start_operation(
                     operation_id=operation_name,
-                    total_steps=kwargs.get("total_steps", 100),
+                    total_steps=total_steps,
                     context={
                         "operation": operation_name,
                         "service": self._get_service_name(),
@@ -1148,7 +1184,7 @@ class ServiceOrchestrator(ABC, Generic[T]):
                 )
 
                 # Execute the operation function
-                result = await operation_func(*args, **kwargs)
+                result = await operation_func(*args, **operation_kwargs)
 
                 # Complete the operation
                 operation_progress.complete_operation()

--- a/tests/api/services/training/test_context.py
+++ b/tests/api/services/training/test_context.py
@@ -1,0 +1,111 @@
+"""Tests for training service context helpers."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ktrdr.api.endpoints.strategies import ValidationIssue
+from ktrdr.errors import ValidationError
+
+
+@pytest.fixture
+def strategy_yaml(tmp_path: Path) -> Path:
+    """Create a minimal strategy YAML file for tests."""
+    strategy_dir = tmp_path / "strategies"
+    strategy_dir.mkdir()
+    strategy_file = strategy_dir / "test_strategy.yaml"
+    strategy_file.write_text(
+        """
+indicators: []
+fuzzy_sets: []
+model:
+  type: mlp
+  training:
+    epochs: 25
+    batch_size: 64
+""".strip()
+    )
+    return strategy_file
+
+
+def make_issue(message: str) -> ValidationIssue:
+    """Helper to build an error-level validation issue."""
+    return ValidationIssue(
+        severity="error",
+        category="structure",
+        message=message,
+        details=None,
+    )
+
+
+class TestBuildTrainingContext:
+    """Behaviour tests for build_training_context factory."""
+
+    def test_successful_context_build(self, strategy_yaml: Path):
+        from ktrdr.api.services.training.context import build_training_context
+
+        with patch(
+            "ktrdr.api.services.training.context._validate_strategy_config",
+            return_value=[],
+        ):
+            context = build_training_context(
+                operation_id="op-123",
+                strategy_name="test_strategy",
+                symbols=["AAPL"],
+                timeframes=["1h"],
+                start_date="2024-01-01",
+                end_date="2024-06-01",
+                detailed_analytics=True,
+                use_host_service=False,
+                strategy_search_paths=[strategy_yaml.parent],
+            )
+
+        assert context.operation_id == "op-123"
+        assert context.strategy_path == strategy_yaml
+        assert context.training_mode == "local"
+        assert context.analytics_enabled is True
+        assert context.total_epochs == 25
+        assert context.total_batches is None
+        assert context.metadata.symbol == "AAPL"
+        assert context.metadata.timeframe == "1h"
+        assert context.metadata.mode == "training"
+        assert context.metadata.parameters["strategy_name"] == "test_strategy"
+        assert context.metadata.parameters["use_host_service"] is False
+        assert context.training_config["epochs"] == 25
+
+    def test_missing_strategy_file(self, tmp_path: Path):
+        from ktrdr.api.services.training.context import build_training_context
+
+        with pytest.raises(ValidationError, match="Strategy file not found"):
+            build_training_context(
+                operation_id="op-missing",
+                strategy_name="missing_strategy",
+                symbols=["AAPL"],
+                timeframes=["1h"],
+                start_date=None,
+                end_date=None,
+                detailed_analytics=False,
+                use_host_service=False,
+                strategy_search_paths=[tmp_path],
+            )
+
+    def test_validation_failure(self, strategy_yaml: Path):
+        from ktrdr.api.services.training.context import build_training_context
+
+        with patch(
+            "ktrdr.api.services.training.context._validate_strategy_config",
+            return_value=[make_issue("broken config")],
+        ):
+            with pytest.raises(ValidationError, match="Strategy validation failed"):
+                build_training_context(
+                    operation_id="op-invalid",
+                    strategy_name="test_strategy",
+                    symbols=["AAPL"],
+                    timeframes=["1h"],
+                    start_date=None,
+                    end_date=None,
+                    detailed_analytics=False,
+                    use_host_service=False,
+                    strategy_search_paths=[strategy_yaml.parent],
+                )

--- a/tests/api/services/training/test_progress_bridge.py
+++ b/tests/api/services/training/test_progress_bridge.py
@@ -1,0 +1,60 @@
+"""Tests for the stub training progress bridge."""
+
+from collections import deque
+from typing import Any
+
+import pytest
+
+from ktrdr.api.services.training.progress_bridge import TrainingProgressBridge
+from ktrdr.async_infrastructure.progress import GenericProgressManager
+
+
+class TestTrainingProgressBridge:
+    """Behaviour tests for the placeholder progress bridge."""
+
+    def test_updates_generic_progress_manager(self):
+        states = deque()
+
+        progress_manager = GenericProgressManager(callback=states.append)
+        progress_manager.start_operation("training", total_steps=5)
+
+        bridge = TrainingProgressBridge(
+            progress_manager=progress_manager, total_steps=5
+        )
+
+        bridge.on_phase("data_loading")
+        assert states[-1].message == "Phase: data_loading"
+        assert states[-1].current_step == 0
+        assert states[-1].percentage == 0.0
+
+        bridge.on_epoch(1, total_epochs=10)
+        assert states[-1].message == "Epoch 1/10"
+        assert states[-1].current_step == 0
+
+        bridge.on_complete("done")
+        assert states[-1].message == "done"
+        assert states[-1].current_step == 5
+        assert states[-1].percentage == pytest.approx(100.0)
+
+    def test_works_with_update_callback(self):
+        captured: list[dict[str, Any]] = []
+
+        def fake_update(**kwargs):
+            captured.append(kwargs)
+
+        bridge = TrainingProgressBridge(
+            update_progress_callback=fake_update, total_steps=3
+        )
+
+        bridge.on_epoch(2, total_epochs=8, metrics={"loss": 0.5})
+        assert captured[-1]["step"] == 0
+        assert captured[-1]["message"] == "Epoch 2/8"
+        assert captured[-1]["items_processed"] == 0
+        assert captured[-1]["phase"] == "epoch"
+        assert captured[-1]["metrics"] == {"loss": 0.5}
+
+        bridge.on_complete()
+        assert captured[-1]["step"] == 3
+        assert captured[-1]["items_processed"] == 3
+        assert captured[-1]["phase"] == "completed"
+        assert captured[-1]["message"] == "Training complete"


### PR DESCRIPTION
## Summary
- convert TrainingService to use ServiceOrchestrator and context factory
- add TrainingOperationContext plus stub TrainingProgressBridge
- update endpoint wiring and orchestrator metadata handling, refresh tests

## Testing
- UV_CACHE_DIR=.uv_cache uv run make test-unit
- UV_CACHE_DIR=.uv_cache uv run make quality