### PR TITLE
feat(v1.5): M3 - Run Experiments

### DIFF
--- a/docs/agentic/v1.5/EXECUTION_LOG.md
+++ b/docs/agentic/v1.5/EXECUTION_LOG.md
@@ -60,10 +60,10 @@
 
 | Strategy | Started | Operation ID | Status | Duration | Notes |
 |----------|---------|--------------|--------|----------|-------|
-| v15_rsi_zigzag_1.5 | - | - | pending | - | - |
-| v15_rsi_zigzag_2.0 | - | - | pending | - | - |
-| v15_rsi_zigzag_3.0 | - | - | pending | - | - |
-| v15_rsi_zigzag_3.5 | - | - | pending | - | - |
+| v15_rsi_zigzag_1_5 | - | - | pending | - | - |
+| v15_rsi_zigzag_2_0 | - | - | pending | - | - |
+| v15_rsi_zigzag_3_0 | - | - | pending | - | - |
+| v15_rsi_zigzag_3_5 | - | - | pending | - | - |
 
 ---
 

--- a/scripts/run_v15_experiments.sh
+++ b/scripts/run_v15_experiments.sh
@@ -65,10 +65,10 @@ STRATEGIES=(
   "v15_mfi_adx_aroon"
   "v15_williams_stochastic_cmf"
   # Zigzag Threshold Variations (4)
-  "v15_rsi_zigzag_1.5"
-  "v15_rsi_zigzag_2.0"
-  "v15_rsi_zigzag_3.0"
-  "v15_rsi_zigzag_3.5"
+  "v15_rsi_zigzag_1_5"
+  "v15_rsi_zigzag_2_0"
+  "v15_rsi_zigzag_3_0"
+  "v15_rsi_zigzag_3_5"
 )
 
 API_URL="http://localhost:8000/api/v1"
@@ -113,10 +113,10 @@ run_training() {
   local start_time=$(date +%s)
   local start_timestamp=$(date '+%Y-%m-%d %H:%M')
 
-  # Start training
+  # Start training with explicit date range (2015-2023 as per v1.5 plan)
   local response=$(curl -s -X POST "$API_URL/trainings/start" \
     -H "Content-Type: application/json" \
-    -d "{\"strategy_name\": \"$strategy\", \"symbols\": [\"EURUSD\"], \"timeframes\": [\"1h\"], \"detailed_analytics\": true}")
+    -d "{\"strategy_name\": \"$strategy\", \"symbols\": [\"EURUSD\"], \"timeframes\": [\"1h\"], \"detailed_analytics\": true, \"start_date\": \"2015-01-01\", \"end_date\": \"2023-12-31\"}")
 
   local op_id=$(echo "$response" | jq -r '.task_id // empty')
 

--- a/strategies/v15_aroon_only.yaml
+++ b/strategies/v15_aroon_only.yaml
@@ -31,7 +31,7 @@ indicators:
 
 # === FUZZY LOGIC CONFIGURATION ===
 fuzzy_sets:
-  aroon_up_25:
+  aroon_up:
     weak:
       type: "triangular"
       parameters: [0, 25, 40]
@@ -41,7 +41,7 @@ fuzzy_sets:
     strong:
       type: "triangular"
       parameters: [60, 75, 100]
-  aroon_down_25:
+  aroon_down:
     weak:
       type: "triangular"
       parameters: [0, 25, 40]

--- a/strategies/v15_williams_only.yaml
+++ b/strategies/v15_williams_only.yaml
@@ -25,7 +25,7 @@ training_data:
 
 # === TECHNICAL INDICATORS ===
 indicators:
-  - name: "williams_r"
+  - name: "williamsr"
     feature_id: williams_14
     period: 14
     source: "close"


### PR DESCRIPTION
## Summary

- Task 3.1: Created EXECUTION_LOG.md to track all 27 strategy training runs
- Task 3.2: Created run_v15_experiments.sh script to automate training
- Task 3.3: Verified analytics output (26/27 completed successfully)
- Task 3.4: Fixed 6 failing strategies, documented 1 unfixable (CMF needs volume data)

## Fixes Applied

| Issue | Fix |
|-------|-----|
| `williams_r` indicator not found | Changed to `williamsr` |
| Aroon fuzzy set mismatch | Simplified to use `aroon_25` feature_id |
| Zigzag strategy names with periods | Renamed to use underscores |
| Wrong date range (2020-2025) | Added explicit 2015-2023 date range to API |

## Results

| Metric | Value |
|--------|-------|
| Completed | 26/27 (96%) |
| Failed | 1 (cmf_only - forex volume issue) |
| Training time | ~1-2 min per strategy |

**Note:** Strategy YAML files live in main ktrdr2 repo (gitignored here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)