### PR TITLE
fix(docker): include alembic in production images

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -86,6 +86,8 @@ COPY --from=builder /app/ktrdr /app/ktrdr
 COPY --from=builder /app/mcp /app/mcp
 COPY --from=builder /app/config /app/config
 COPY --from=builder /app/strategies /app/strategies
+COPY --from=builder /app/alembic /app/alembic
+COPY --from=builder /app/alembic.ini /app/
 COPY --from=builder /app/pyproject.toml /app/
 
 # Change ownership of the app directory (after copying files)

--- a/deploy/docker/Dockerfile.patch
+++ b/deploy/docker/Dockerfile.patch
@@ -92,6 +92,8 @@ COPY --from=builder /app/ktrdr /app/ktrdr
 COPY --from=builder /app/mcp /app/mcp
 COPY --from=builder /app/config /app/config
 COPY --from=builder /app/strategies /app/strategies
+COPY --from=builder /app/alembic /app/alembic
+COPY --from=builder /app/alembic.ini /app/
 COPY --from=builder /app/pyproject.toml /app/
 
 # Change ownership of the app directory


### PR DESCRIPTION
## Summary
- Add `alembic/` directory and `alembic.ini` to both production and patch Dockerfiles
- Enables running database migrations from within containers

## Why
The checkpoint system (M1-M8) added database tables via alembic migrations:
- `operations` - persistent operation tracking
- `operation_checkpoints` - checkpoint storage for resume functionality

Without alembic in the image, migrations cannot be run during deployment.

## Test plan
- [ ] CI builds successfully
- [ ] Deploy to pre-prod: `uv run ktrdr deploy core`
- [ ] Run migrations: `docker exec -it ktrdr-backend bash -c "cd /app && python -m alembic upgrade head"`
- [ ] Verify tables exist: `docker exec -it ktrdr-db psql -U <user> -d ktrdr -c "\dt"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)