### PR TITLE
fix(cli): unified --url flag support across all commands

### DIFF
--- a/ktrdr/cli/async_cli_client.py
+++ b/ktrdr/cli/async_cli_client.py
@@ -61,9 +61,9 @@ class AsyncCLIClient:
         # Priority: explicit parameter > global --url override > config default
         url_override = base_url or get_api_url_override()
         if url_override:
-            # Auto-append /api/v1 if not present (user typically provides just host:port)
+            # Auto-append /api/v1 if no API path present (user typically provides just host:port)
             effective_url = url_override.rstrip("/")
-            if not effective_url.endswith("/api/v1"):
+            if "/api/" not in effective_url:
                 effective_url = f"{effective_url}/api/v1"
         else:
             effective_url = cli_settings.base_url

--- a/ktrdr/cli/checkpoints_commands.py
+++ b/ktrdr/cli/checkpoints_commands.py
@@ -16,6 +16,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ktrdr.cli.api_client import check_api_connection, get_api_client
+from ktrdr.cli.commands import get_effective_api_url
 from ktrdr.cli.telemetry import trace_cli_command
 from ktrdr.config.validation import InputValidator
 from ktrdr.errors import DataError, ValidationError
@@ -116,7 +117,7 @@ async def _show_checkpoint_async(operation_id: str, verbose: bool):
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -283,7 +284,7 @@ async def _delete_checkpoint_async(operation_id: str, force: bool, verbose: bool
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
             return

--- a/ktrdr/cli/error_handler.py
+++ b/ktrdr/cli/error_handler.py
@@ -10,13 +10,13 @@ from typing import Any, Optional
 
 from rich.console import Console
 
+from ktrdr.cli.commands import get_effective_api_url
 from ktrdr.cli.ib_diagnosis import (
     IBProblemType,
     detect_ib_issue_from_api_response,
     get_ib_recovery_suggestions,
     should_show_ib_diagnosis,
 )
-from ktrdr.config.host_services import get_api_base_url
 from ktrdr.errors import DataError, ValidationError
 from ktrdr.errors.exceptions import (
     ServiceConfigurationError,
@@ -241,7 +241,7 @@ def display_ib_connection_required_message() -> None:
     error_console.print(
         "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
     )
-    error_console.print(f"Make sure the API server is running at {get_api_base_url()}")
+    error_console.print(f"Make sure the API server is running at {get_effective_api_url()}")
 
 
 def create_enhanced_exception_handler(verbose: bool = False, quiet: bool = False):

--- a/ktrdr/cli/fuzzy_commands.py
+++ b/ktrdr/cli/fuzzy_commands.py
@@ -17,6 +17,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ktrdr.cli.api_client import check_api_connection, get_api_client
+from ktrdr.cli.commands import get_effective_api_url
 from ktrdr.cli.telemetry import trace_cli_command
 from ktrdr.config.validation import InputValidator
 from ktrdr.errors import DataError, ValidationError
@@ -135,7 +136,7 @@ async def _compute_fuzzy_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -355,7 +356,7 @@ async def _visualize_fuzzy_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -483,7 +484,7 @@ async def _manage_config_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 

--- a/ktrdr/cli/indicator_commands.py
+++ b/ktrdr/cli/indicator_commands.py
@@ -17,8 +17,8 @@ from rich.console import Console
 from rich.table import Table
 
 from ktrdr.cli.api_client import check_api_connection, get_api_client
+from ktrdr.cli.commands import get_effective_api_url
 from ktrdr.cli.telemetry import trace_cli_command
-from ktrdr.config.host_services import get_api_base_url
 from ktrdr.config.validation import InputValidator
 from ktrdr.errors import DataError, ValidationError
 from ktrdr.logging import get_logger
@@ -122,7 +122,7 @@ async def _compute_indicator_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                f"Make sure the API server is running at {get_api_base_url()}"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -333,7 +333,7 @@ async def _plot_chart_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                f"Make sure the API server is running at {get_api_base_url()}"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -416,7 +416,7 @@ async def _list_indicators_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                f"Make sure the API server is running at {get_api_base_url()}"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 

--- a/ktrdr/cli/model_commands.py
+++ b/ktrdr/cli/model_commands.py
@@ -28,6 +28,7 @@ from rich.table import Table
 
 from ktrdr.cli.api_client import check_api_connection, get_api_client
 from ktrdr.cli.async_cli_client import AsyncCLIClient, AsyncCLIClientError
+from ktrdr.cli.commands import get_effective_api_url
 from ktrdr.config.strategy_loader import strategy_loader
 from ktrdr.config.validation import InputValidator
 from ktrdr.errors import DataError, ValidationError
@@ -665,7 +666,7 @@ async def _list_models_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -832,7 +833,7 @@ async def _test_model_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -967,7 +968,7 @@ async def _make_prediction_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 

--- a/ktrdr/cli/operations_commands.py
+++ b/ktrdr/cli/operations_commands.py
@@ -17,6 +17,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ktrdr.cli.api_client import check_api_connection, get_api_client
+from ktrdr.cli.commands import get_effective_api_url
 from ktrdr.cli.telemetry import trace_cli_command
 from ktrdr.config.validation import InputValidator
 from ktrdr.errors import DataError, ValidationError
@@ -203,7 +204,7 @@ async def _list_operations_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -392,7 +393,7 @@ async def _get_operation_status_async(operation_id: str, verbose: bool):
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -579,7 +580,7 @@ async def _cancel_operation_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -695,7 +696,7 @@ async def _retry_operation_async(operation_id: str, verbose: bool):
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 
@@ -789,7 +790,7 @@ async def _resume_operation_async(operation_id: str, verbose: bool):
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 

--- a/ktrdr/cli/strategy_commands.py
+++ b/ktrdr/cli/strategy_commands.py
@@ -25,6 +25,7 @@ from rich.progress import (
 from rich.table import Table
 
 from ktrdr.cli.api_client import check_api_connection, get_api_client
+from ktrdr.cli.commands import get_effective_api_url
 from ktrdr.cli.telemetry import trace_cli_command
 from ktrdr.config.strategy_loader import strategy_loader
 from ktrdr.config.strategy_validator import StrategyValidator
@@ -328,7 +329,7 @@ async def run_backtest_async(
                 "[bold red]Error:[/bold red] Could not connect to KTRDR API server"
             )
             error_console.print(
-                "Make sure the API server is running at http://localhost:8000"
+                f"Make sure the API server is running at {get_effective_api_url()}"
             )
             sys.exit(1)
 


### PR DESCRIPTION
## Summary
- Add URL normalization: auto-prepend `http://`, add default port `:8000`
- Make all API clients respect `--url` flag (`KtrdrApiClient`, `AsyncCLIClient`, `AsyncOperationExecutor`)
- Fix hardcoded `localhost:8000` in error messages to use effective URL
- Future-proof API prefix detection (checks for `/api/` not just `/api/v1`)

## Problem
Previously, the `--url` flag was only respected by `AsyncCLIClient`. Other clients (`KtrdrApiClient`, `AsyncOperationExecutor`) ignored it, causing commands like `data range` to still hit localhost.

Also required full URL format like `http://backend.example.com:8000`.

## Solution
Now all CLI commands use the `--url` flag consistently, and URL format is flexible:

```bash
# All these work now:
ktrdr -u backend.example.com data range EURUSD
ktrdr -u backend.example.com:9000 agent trigger
ktrdr -u http://backend.example.com:8000 operations list
```

## Test plan
- [x] Tested `data range` command with remote URL
- [x] Tested `agent trigger` command with remote URL  
- [x] Verified error messages show effective URL (not hardcoded localhost)
- [x] Ran `ruff check` - all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)