### PR TITLE
fix(sandbox): use fixed internal ports for workers

### DIFF
--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -204,7 +204,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 30s
     ports:
-      - "${KTRDR_WORKER_PORT_1:-5003}:${KTRDR_WORKER_PORT_1:-5003}"
+      - "${KTRDR_WORKER_PORT_1:-5003}:5003"
     volumes:
       - ./ktrdr:/app/ktrdr
       - ./logs:/app/logs
@@ -221,8 +221,8 @@ services:
       - PYTHONPATH=/app
       - KTRDR_API_URL=http://backend:8000
       - WORKER_TYPE=backtesting
-      - WORKER_PORT=${KTRDR_WORKER_PORT_1:-5003}
-      - WORKER_PUBLIC_BASE_URL=http://backtest-worker-1:${KTRDR_WORKER_PORT_1:-5003}
+      - WORKER_PORT=5003
+      - WORKER_PUBLIC_BASE_URL=http://backtest-worker-1:5003
       - OTLP_ENDPOINT=http://jaeger:4317
       - CHECKPOINT_DIR=/app/data/checkpoints
       - DB_HOST=db
@@ -233,7 +233,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${KTRDR_WORKER_PORT_1:-5003}/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5003/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -245,7 +245,7 @@ services:
         condition: service_healthy
       backend:
         condition: service_started
-    command: /app/.venv/bin/uvicorn ktrdr.backtesting.backtest_worker:app --host 0.0.0.0 --port ${KTRDR_WORKER_PORT_1:-5003} --reload
+    command: /app/.venv/bin/uvicorn ktrdr.backtesting.backtest_worker:app --host 0.0.0.0 --port 5003 --reload
 
   # Backtest Worker 2
   backtest-worker-2:
@@ -258,7 +258,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 30s
     ports:
-      - "${KTRDR_WORKER_PORT_2:-5004}:${KTRDR_WORKER_PORT_2:-5004}"
+      - "${KTRDR_WORKER_PORT_2:-5004}:5004"
     volumes:
       - ./ktrdr:/app/ktrdr
       - ./logs:/app/logs
@@ -274,8 +274,8 @@ services:
       - PYTHONPATH=/app
       - KTRDR_API_URL=http://backend:8000
       - WORKER_TYPE=backtesting
-      - WORKER_PORT=${KTRDR_WORKER_PORT_2:-5004}
-      - WORKER_PUBLIC_BASE_URL=http://backtest-worker-2:${KTRDR_WORKER_PORT_2:-5004}
+      - WORKER_PORT=5004
+      - WORKER_PUBLIC_BASE_URL=http://backtest-worker-2:5004
       - OTLP_ENDPOINT=http://jaeger:4317
       - CHECKPOINT_DIR=/app/data/checkpoints
       - DB_HOST=db
@@ -286,7 +286,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${KTRDR_WORKER_PORT_2:-5004}/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5004/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -298,7 +298,7 @@ services:
         condition: service_healthy
       backend:
         condition: service_started
-    command: /app/.venv/bin/uvicorn ktrdr.backtesting.backtest_worker:app --host 0.0.0.0 --port ${KTRDR_WORKER_PORT_2:-5004} --reload
+    command: /app/.venv/bin/uvicorn ktrdr.backtesting.backtest_worker:app --host 0.0.0.0 --port 5004 --reload
 
   # Training Worker 1
   training-worker-1:
@@ -311,7 +311,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 30s
     ports:
-      - "${KTRDR_WORKER_PORT_3:-5005}:${KTRDR_WORKER_PORT_3:-5005}"
+      - "${KTRDR_WORKER_PORT_3:-5005}:5005"
     volumes:
       - ./ktrdr:/app/ktrdr
       - ./logs:/app/logs
@@ -327,8 +327,8 @@ services:
       - PYTHONPATH=/app
       - KTRDR_API_URL=http://backend:8000
       - WORKER_TYPE=training
-      - WORKER_PORT=${KTRDR_WORKER_PORT_3:-5005}
-      - WORKER_PUBLIC_BASE_URL=http://training-worker-1:${KTRDR_WORKER_PORT_3:-5005}
+      - WORKER_PORT=5005
+      - WORKER_PUBLIC_BASE_URL=http://training-worker-1:5005
       - OTLP_ENDPOINT=http://jaeger:4317
       - CHECKPOINT_DIR=/app/data/checkpoints
       - DB_HOST=db
@@ -339,7 +339,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${KTRDR_WORKER_PORT_3:-5005}/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5005/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -351,7 +351,7 @@ services:
         condition: service_healthy
       backend:
         condition: service_started
-    command: /app/.venv/bin/uvicorn ktrdr.training.training_worker:app --host 0.0.0.0 --port ${KTRDR_WORKER_PORT_3:-5005} --reload
+    command: /app/.venv/bin/uvicorn ktrdr.training.training_worker:app --host 0.0.0.0 --port 5005 --reload
 
   # Training Worker 2
   training-worker-2:
@@ -364,7 +364,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 30s
     ports:
-      - "${KTRDR_WORKER_PORT_4:-5006}:${KTRDR_WORKER_PORT_4:-5006}"
+      - "${KTRDR_WORKER_PORT_4:-5006}:5006"
     volumes:
       - ./ktrdr:/app/ktrdr
       - ./logs:/app/logs
@@ -380,8 +380,8 @@ services:
       - PYTHONPATH=/app
       - KTRDR_API_URL=http://backend:8000
       - WORKER_TYPE=training
-      - WORKER_PORT=${KTRDR_WORKER_PORT_4:-5006}
-      - WORKER_PUBLIC_BASE_URL=http://training-worker-2:${KTRDR_WORKER_PORT_4:-5006}
+      - WORKER_PORT=5006
+      - WORKER_PUBLIC_BASE_URL=http://training-worker-2:5006
       - OTLP_ENDPOINT=http://jaeger:4317
       - CHECKPOINT_DIR=/app/data/checkpoints
       - DB_HOST=db
@@ -392,7 +392,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${KTRDR_WORKER_PORT_4:-5006}/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5006/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -404,7 +404,7 @@ services:
         condition: service_healthy
       backend:
         condition: service_started
-    command: /app/.venv/bin/uvicorn ktrdr.training.training_worker:app --host 0.0.0.0 --port ${KTRDR_WORKER_PORT_4:-5006} --reload
+    command: /app/.venv/bin/uvicorn ktrdr.training.training_worker:app --host 0.0.0.0 --port 5006 --reload
 
 networks:
   ktrdr-network:


### PR DESCRIPTION
## Summary

Fixes worker internal ports to be fixed (5003-5006) per DESIGN.md Decision 12.

## Problem

Prometheus was trying to scrape workers on ports 5003-5006 but sandbox workers were listening on 5010-5013 (parameterized internal ports). This caused:
- Prometheus targets showing "down"
- Grafana worker dashboards showing unhealthy

## Fix

Workers now:
- Listen on fixed internal ports: 5003, 5004, 5005, 5006
- Map to parameterized external ports: `${KTRDR_WORKER_PORT_X}:500Y`
- Use fixed ports in `WORKER_PORT` and `WORKER_PUBLIC_BASE_URL`

## Test plan

- [ ] Restart sandbox: `ktrdr sandbox down && ktrdr sandbox up`
- [ ] Check Prometheus targets: `curl http://localhost:9091/api/v1/targets`
- [ ] Verify Grafana worker dashboard shows healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)