### PR TITLE
fix(observability): remove TEMP DEBUG logging from operations_service

### DIFF
--- a/ktrdr/api/services/operations_service.py
+++ b/ktrdr/api/services/operations_service.py
@@ -432,11 +432,6 @@ class OperationsService:
         # - Complete/Fail (once)
         # Progress updates stay in-memory; clients pull via proxy for live progress.
 
-        # 🔧 TEMP DEBUG: Log ALL progress updates at INFO level
-        logger.info(
-            f"📊 Operation {operation_id} progress: {progress.percentage:.1f}% - {progress.current_step or 'Loading'}"
-        )
-
     async def complete_operation(
         self,
         operation_id: str,


### PR DESCRIPTION
## Summary

Remove temporary debug logging that was logging every progress update at INFO level, causing excessive log volume in production.

## Changes

- Removed 4 lines of TEMP DEBUG logging from `ktrdr/api/services/operations_service.py:435-438`
- Progress updates are already tracked in-memory for clients to pull via the proxy

## Testing

- Unit tests: 4104 passed
- Quality checks: All passed

## Acceptance Criteria

- [x] Remove or change to DEBUG level (removed entirely)
- [x] Verify no excessive logging during operation execution

Closes #228

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)