### PR TITLE
fix(cli): sandbox auto-detection for M2 commands

### DIFF
--- a/ktrdr/cli/client/core.py
+++ b/ktrdr/cli/client/core.py
@@ -73,11 +73,11 @@ def resolve_url(explicit_url: Optional[str] = None) -> str:
     # Priority 3: Check sandbox detection (fixes issue #252)
     # M2 commands use app.py callback which doesn't set legacy _cli_state,
     # so we need to check sandbox detection directly as a fallback.
-    from ktrdr.cli.sandbox_detect import resolve_api_url as sandbox_resolve
+    from ktrdr.cli import sandbox_detect
 
-    sandbox_url = sandbox_resolve()
-    if sandbox_url != "http://localhost:8000":
-        # Sandbox detected - use it with /api/v1 path
+    if sandbox_detect.find_env_sandbox() is not None:
+        # Sandbox detected - use resolved URL with /api/v1 path
+        sandbox_url = sandbox_detect.resolve_api_url()
         return f"{sandbox_url}/api/v1"
 
     return get_api_base_url().rstrip("/")

--- a/tests/unit/cli/client/test_core.py
+++ b/tests/unit/cli/client/test_core.py
@@ -146,24 +146,24 @@ class TestResolveUrl:
             # Should use sandbox-detected URL, not config default
             assert result == "http://localhost:8001/api/v1"
 
+    @patch("ktrdr.cli.sandbox_detect.find_env_sandbox")
     @patch("ktrdr.cli.client.core.get_api_url_override")
+    @patch("ktrdr.cli.client.core.get_api_base_url")
     def test_sandbox_detection_skipped_when_no_sandbox_file(
-        self, mock_override, tmp_path
+        self, mock_base, mock_override, mock_find_sandbox
     ):
         """Falls back to config default when no .env.sandbox exists.
 
         Ensures sandbox detection doesn't break when not in a sandbox directory.
         """
         mock_override.return_value = None
+        mock_base.return_value = "http://localhost:8000/api/v1"
+        mock_find_sandbox.return_value = None  # No sandbox detected
 
-        # Mock sandbox detection to return None (no .env.sandbox file)
-        with patch("ktrdr.cli.sandbox_detect.find_env_sandbox") as mock_find_sandbox:
-            mock_find_sandbox.return_value = None
+        result = resolve_url(None)
 
-            result = resolve_url(None)
-
-            # Should fall back to config default
-            assert "localhost:8000" in result
+        # Should fall back to config default
+        assert result == "http://localhost:8000/api/v1"
 
 
 class TestShouldRetry:


### PR DESCRIPTION
## Summary

- Fixed sandbox auto-detection not working for M2 commands (research, train, etc.)
- Added sandbox detection as a fallback in `resolve_url()` when `get_api_url_override()` returns `None`
- Added tests for the new sandbox detection fallback behavior

## Problem

The CLI's sandbox auto-detection was broken for M2 commands like `ktrdr research`. When running from a sandbox directory (e.g., `ktrdr--indicator-std`), commands would incorrectly target `http://localhost:8000` instead of the sandbox port (`http://localhost:8001`).

**Root cause:** M2 commands use `app.py`'s callback which sets `ctx.obj.api_url` but doesn't set the legacy `_cli_state["api_url"]`. When `AsyncCLIClient` called `resolve_url()`, it checked `get_api_url_override()` (which reads from `_cli_state`), and when that returned `None`, it fell through directly to the config default, bypassing sandbox detection.

## Solution

Added sandbox detection as priority 3 in the URL resolution chain:
1. Explicit URL parameter (highest)
2. `--url` flag override (legacy `_cli_state`)
3. **Sandbox detection from `.env.sandbox` file** ← NEW
4. Config default (lowest)

## Changes

- `ktrdr/cli/client/core.py`: Added sandbox detection fallback in `resolve_url()`
- `tests/unit/cli/client/test_core.py`: Added tests for sandbox detection behavior

## Testing

- Unit tests: 4069 passed
- Quality checks: All passed (lint, format, typecheck)
- **E2E validation passed:**
  ```
  $ uv run ktrdr research "test sandbox detection" --model haiku
  Started research: op_agent_research_20260119_154342_9b5e19ea
  
  $ uv run ktrdr status op_agent_research_20260119_154342_9b5e19ea
  Operation: op_agent_research_20260119_154342_9b5e19ea
  Type: agent_research
  Status: running
  Progress: 5.0%
  ```
  Before the fix, this would have failed with `Could not connect to API at http://localhost:8000`

## Acceptance Criteria

- [x] Commands automatically detect and use the sandbox port from `.env.sandbox`
- [x] No explicit environment variables required for sandbox detection to work
- [x] E2E validation: research command successfully targets sandbox backend

Closes #252