### PR TITLE
feat(cli): Add consistent result display formatting for OperationRunner

### DIFF
--- a/tests/unit/cli/test_operation_runner.py
+++ b/tests/unit/cli/test_operation_runner.py
@@ -358,9 +358,9 @@ class TestOperationRunnerResultDisplay:
         runner._display_results(backtest_data, "backtest")
         backtest_output = capsys.readouterr().out
 
-        # Both should use "Results:" header pattern
-        assert "Results:" in training_output or "Results" in training_output
-        assert "Results:" in backtest_output or "Results" in backtest_output
+        # Both should use consistent "Results:" header pattern
+        assert "Training Results:" in training_output
+        assert "Backtest Results:" in backtest_output
 
     def test_display_results_empty_summary_json_mode(
         self, capsys: pytest.CaptureFixture
@@ -394,7 +394,7 @@ class TestOperationRunnerResultDisplay:
         runner._display_results(op_data, "training")
 
         captured = capsys.readouterr()
-        # Should output valid JSON indicating no results
+        # Should output valid JSON with empty results dict
         output = json.loads(captured.out)
         assert output["operation_type"] == "training"
-        assert output["results"] is None or output["results"] == {}
+        assert output["results"] == {}


### PR DESCRIPTION
## Summary

- Add JSON mode support for operation result display in `OperationRunner._display_results()`
- Standardize result extraction and formatting across all operation types
- Add generic result display fallback for unknown operation types using Rich tables
- Comprehensive unit tests for JSON and human-readable output modes

## Changes

- **`ktrdr/cli/operation_runner.py`**: Refactored `_display_results()` to support JSON mode and provide consistent formatting:
  - `_extract_results()`: Normalizes results based on operation type
  - `_display_results_json()`: Outputs structured JSON for scripting
  - `_display_results_human()`: Routes to operation-specific or generic formatters
  - `_display_generic_results_human()`: Uses Rich table for unknown operation types

- **`tests/unit/cli/test_operation_runner.py`**: Added 6 new tests:
  - JSON mode for training results
  - JSON mode for backtest results
  - JSON mode for unknown operation types
  - Consistent header format for human-readable output
  - Empty result_summary handling
  - None result_summary handling

## Testing

- Unit tests: 6 new tests added, all passing
- Full test suite: 4212 tests pass
- Quality checks: lint, format, typecheck all pass

## Acceptance Criteria

- [x] All operation types use consistent result display formatting
- [x] JSON output follows standardized structure
- [x] Human-readable output has consistent styling and information hierarchy
- [x] Error scenarios display consistently across operation types

Closes #204