### PR TITLE
fix(host-services): use shared data directories from .env.sandbox

### DIFF
--- a/ktrdr/cli/local_prod.py
+++ b/ktrdr/cli/local_prod.py
@@ -447,11 +447,26 @@ def _get_host_service_env(cwd: Path) -> dict[str, str]:
     env["DB_NAME"] = "ktrdr"
     env["DB_USER"] = "ktrdr"
 
-    # Set shared directories (absolute paths for host services)
-    # These ensure host services use the same data/models/strategies as the main system
-    env["DATA_DIR"] = str(cwd / "data")
-    env["MODELS_DIR"] = str(cwd / "models")
-    env["STRATEGIES_DIR"] = str(cwd / "strategies")
+    # Read shared directory paths from .env.sandbox
+    # (These are set by instance_core.py to point to ~/.ktrdr/shared/)
+    sandbox_env = load_env_file(cwd)
+    if sandbox_env:
+        shared_fallback = Path.home() / ".ktrdr" / "shared"
+        env["DATA_DIR"] = sandbox_env.get(
+            "KTRDR_DATA_DIR", str(shared_fallback / "data")
+        )
+        env["MODELS_DIR"] = sandbox_env.get(
+            "KTRDR_MODELS_DIR", str(shared_fallback / "models")
+        )
+        env["STRATEGIES_DIR"] = sandbox_env.get(
+            "KTRDR_STRATEGIES_DIR", str(shared_fallback / "strategies")
+        )
+    else:
+        # Fallback to canonical shared directory if .env.sandbox missing
+        shared_dir = Path.home() / ".ktrdr" / "shared"
+        env["DATA_DIR"] = str(shared_dir / "data")
+        env["MODELS_DIR"] = str(shared_dir / "models")
+        env["STRATEGIES_DIR"] = str(shared_dir / "strategies")
 
     return env
 

--- a/training-host-service/orchestrator.py
+++ b/training-host-service/orchestrator.py
@@ -825,17 +825,19 @@ class HostTrainingOrchestrator:
             strategy_name = strategy_config.get("name", "unnamed")
             base_timeframe = timeframes[0] if timeframes else "1h"
             model_path = self._model_storage.save_model(
-                strategy_name=strategy_name,
-                timeframe=base_timeframe,
                 model=model,
-                metadata={
-                    "feature_names": feature_names,
+                strategy_name=strategy_name,
+                symbol=symbols[0] if symbols else "universal",
+                timeframe=base_timeframe,
+                config=strategy_config,
+                training_metrics={
+                    **training_results,
+                    **test_metrics,
                     "symbols": symbols,
-                    "timeframes": timeframes,
                     "start_date": start_date,
                     "end_date": end_date,
-                    "training_config": training_config,
                 },
+                feature_names=feature_names,
             )
 
             logger.info(f"Model saved to: {model_path}")

--- a/training-host-service/services/training_service.py
+++ b/training-host-service/services/training_service.py
@@ -308,15 +308,18 @@ class TrainingService:
         self.session_timeout_minutes = session_timeout_minutes
         self.sessions: dict[str, TrainingSession] = {}
 
-        # Model storage - host service has situational awareness of shared models path
-        # Host service runs from training-host-service/, models are in project root
+        # Model storage - use MODELS_DIR env var (set by local_prod.py from .env.sandbox)
+        # Falls back to project root if env var not set
+        import os
         from pathlib import Path
 
         from ktrdr.training.model_storage import ModelStorage
 
-        project_root = Path(__file__).parent.parent.parent
-        models_path = project_root / "models"
-        self.model_storage = ModelStorage(base_path=str(models_path))
+        models_dir = os.getenv("MODELS_DIR")
+        if not models_dir:
+            project_root = Path(__file__).parent.parent.parent
+            models_dir = str(project_root / "models")
+        self.model_storage = ModelStorage(base_path=models_dir)
 
         # Global resource managers
         self.global_gpu_manager: Optional[GPUMemoryManager] = None


### PR DESCRIPTION
## Summary

- Host services (training-host, ib-host) were hardcoding `DATA_DIR`, `MODELS_DIR`, `STRATEGIES_DIR` to repo-local paths that don't exist
- Now reads `KTRDR_*_DIR` from `.env.sandbox` (set by `instance_core.py` to `~/.ktrdr/shared/`)
- Also fixes `ModelStorage` init and `save_model()` call in host orchestrator

## Changes

- **`ktrdr/cli/local_prod.py`**: `_get_host_service_env()` reads shared directory paths from `.env.sandbox` via `load_env_file()` instead of hardcoding `cwd / "data"` etc.
- **`training-host-service/services/training_service.py`**: `ModelStorage` uses `MODELS_DIR` env var instead of hardcoded `project_root / "models"`
- **`training-host-service/orchestrator.py`**: Fixed `save_model()` call to match `ModelStorage.save_model()` signature (was passing non-existent `metadata` kwarg)

## Testing

- `make quality` passes
- `make test-unit` passes (4319 passed, 6 skipped)
- End-to-end verified: `ktrdr train v3_minimal` completes with model saved to `~/.ktrdr/shared/models/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)