### PR TITLE
fix(tests): eliminate budget tracker race condition in agent unit tests

### DIFF
--- a/tests/unit/agent_tests/test_agent_service_new.py
+++ b/tests/unit/agent_tests/test_agent_service_new.py
@@ -138,7 +138,7 @@ class TestAgentServiceTrigger:
                 try:
                     await task
                 except (asyncio.CancelledError, Exception):
-                    pass
+                    pass  # Best-effort cleanup: ignore errors from cancelled tasks
 
     @pytest.fixture(autouse=True)
     def mock_budget(self):
@@ -256,9 +256,15 @@ class TestAgentServiceGetStatus:
         mock_tracker.get_remaining.return_value = 5.0
         mock_tracker.daily_limit = 5.0
 
-        with patch(
-            "ktrdr.api.services.agent_service.get_budget_tracker",
-            return_value=mock_tracker,
+        with (
+            patch(
+                "ktrdr.api.services.agent_service.get_budget_tracker",
+                return_value=mock_tracker,
+            ),
+            patch(
+                "ktrdr.agents.workers.research_worker.get_budget_tracker",
+                return_value=mock_tracker,
+            ),
         ):
             yield mock_tracker
 
@@ -406,9 +412,15 @@ class TestAgentServiceMetadataContract:
         mock_tracker.get_remaining.return_value = 5.0
         mock_tracker.daily_limit = 5.0
 
-        with patch(
-            "ktrdr.api.services.agent_service.get_budget_tracker",
-            return_value=mock_tracker,
+        with (
+            patch(
+                "ktrdr.api.services.agent_service.get_budget_tracker",
+                return_value=mock_tracker,
+            ),
+            patch(
+                "ktrdr.agents.workers.research_worker.get_budget_tracker",
+                return_value=mock_tracker,
+            ),
         ):
             yield mock_tracker
 
@@ -1272,9 +1284,15 @@ class TestAgentServiceMultiResearchStatus:
         mock_tracker.get_remaining.return_value = 5.0
         mock_tracker.daily_limit = 5.0
 
-        with patch(
-            "ktrdr.api.services.agent_service.get_budget_tracker",
-            return_value=mock_tracker,
+        with (
+            patch(
+                "ktrdr.api.services.agent_service.get_budget_tracker",
+                return_value=mock_tracker,
+            ),
+            patch(
+                "ktrdr.agents.workers.research_worker.get_budget_tracker",
+                return_value=mock_tracker,
+            ),
         ):
             yield mock_tracker
 

--- a/tests/unit/agent_tests/test_multi_research.py
+++ b/tests/unit/agent_tests/test_multi_research.py
@@ -642,7 +642,7 @@ class TestTriggerCapacityCheck:
                 try:
                     await task
                 except (asyncio.CancelledError, Exception):
-                    pass
+                    pass  # Best-effort cleanup: ignore errors from cancelled tasks
 
     @pytest.fixture(autouse=True)
     def mock_budget(self):

--- a/tests/unit/agents/test_research_worker_multi.py
+++ b/tests/unit/agents/test_research_worker_multi.py
@@ -578,7 +578,7 @@ class TestCapacityCheck:
                 try:
                     await task
                 except (asyncio.CancelledError, Exception):
-                    pass
+                    pass  # Best-effort cleanup: ignore errors from cancelled tasks
 
     @pytest.fixture(autouse=True)
     def mock_budget(self):
@@ -738,7 +738,7 @@ class TestCoordinatorLifecycle:
                 try:
                     await task
                 except (asyncio.CancelledError, Exception):
-                    pass
+                    pass  # Best-effort cleanup: ignore errors from cancelled tasks
 
     @pytest.fixture(autouse=True)
     def mock_budget(self):


### PR DESCRIPTION
## Summary

- Fixed cross-process race condition where pytest-xdist workers shared a real budget JSON file, causing intermittent `JSONDecodeError` in CI
- Added `cleanup_coordinator` async fixture to cancel leaked background tasks from `trigger()` tests (4 test classes across 3 files)
- Added `mock_budget` fixture to prevent filesystem access in `get_status()` reader tests (3 test classes)
- Unskipped `test_status_returns_last_cycle_when_idle` which was marked flaky in #275

## Root Cause

Three interacting bugs:
1. **Leaked async tasks**: `service.trigger()` spawns background coordinator tasks never cancelled after tests
2. **Incomplete mocking**: Budget mocked at `agent_service` import but not at `research_worker` import — background tasks called real `record_spend()`
3. **Missing mock in readers**: `get_status()` tests read the real budget file that writers were racing on

## Test plan

- [x] `make test-unit` passes (4320 passed, 5 skipped — was 4319/6)
- [x] `make quality` passes
- [x] Parallel xdist stress test: `pytest tests/unit/agent_tests/ -v -n 4 --no-cov` — 545 passed, 0 warnings
- [x] No `PytestDeprecationWarning` for async fixtures

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)