### PR TITLE
fix(klandpr): remove --delete-branch to prevent worktree issues

### DIFF
--- a/.claude/commands/klandpr.md
+++ b/.claude/commands/klandpr.md
@@ -194,10 +194,10 @@ This blocks until all checks complete.
 ### Phase 6: Merge
 
 ```bash
-gh pr merge --squash --delete-branch
+gh pr merge --squash
 ```
 
-**Important:** This merges the PR on GitHub (not a local merge). The `--delete-branch` removes the remote branch after merge.
+**Important:** This merges the PR on GitHub (not a local merge). GitHub automatically deletes the remote branch after merge. We do NOT use `--delete-branch` because it tries to switch to main locally, which fails in a worktree.
 
 ### Phase 7: Cleanup
 


### PR DESCRIPTION
## Summary

Removes the `--delete-branch` flag from the merge command in klandpr.

## Problem

When running `gh pr merge --squash --delete-branch` from a worktree:
1. gh tries to delete the local branch after merge
2. This requires switching to main first
3. But main is already checked out in another worktree
4. The command fails with: `fatal: 'main' is already used by worktree`

This prevented `kinfra done` from running, leaving the sandbox in an inconsistent state.

## Solution

Use `gh pr merge --squash` without `--delete-branch`. GitHub automatically deletes the remote branch after merge anyway. The local branch becomes orphaned but that's fine since `kinfra done` will remove the entire worktree.

## Test plan

- [x] Tested during workers-cli/M1 implementation
- [x] Identified this fix after Phase 7 cleanup failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)