### PR TITLE
feat: autoresearch — autonomous overnight strategy experimentation

### DIFF
--- a/autoresearch/harness.py
+++ b/autoresearch/harness.py
@@ -1,0 +1,187 @@
+"""
+ktrdr-autoresearch harness.
+
+FIXED — do not modify. This file defines the experiment boundaries:
+  - Training window (agent trains on this)
+  - Validation window (metric is measured here; agent optimizes against this)
+  - Test window (NEVER used during the loop; held for final manual review)
+  - The single metric: Sharpe ratio on the validation window
+
+The agent modifies strategy.yaml (strategies/autoresearch.yaml) only.
+
+Prerequisites:
+  - ktrdr backend + training worker + backtest worker must be running
+  - Use `uv run kinfra sandbox up` or the main stack before running
+  - Historical data for the strategy's symbols must be available locally
+
+Usage:
+  cd <ktrdr-root>
+  python autoresearch/harness.py
+"""
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Fixed experiment parameters — do not change during a run
+# ---------------------------------------------------------------------------
+
+STRATEGY_NAME = "autoresearch"          # Resolves to strategies/autoresearch.yaml
+
+TRAIN_START = "2020-01-01"
+TRAIN_END   = "2023-12-31"
+
+VAL_START   = "2024-01-01"
+VAL_END     = "2024-12-31"
+
+# TEST_START = "2025-01-01"  # LOCKED — never used in the autoresearch loop
+
+MAX_TRAIN_SECONDS = 1800   # 30 min hard cap
+MAX_BACKTEST_SECONDS = 300  # 5 min hard cap
+
+VALIDATION_SPLIT = "0.2"
+COMMISSION = "0.001"   # 0.1% — realistic for CFDs/forex
+SLIPPAGE   = "0.0005"  # 0.05%
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def run_ktrdr(args: list[str], timeout: int, label: str) -> dict:
+    """
+    Run a ktrdr CLI command with --json flag, return parsed JSON result.
+    Raises RuntimeError on non-zero exit or unparseable output.
+    """
+    cmd = ["uv", "run", "ktrdr", "--json"] + args
+    print(f"[harness] {label}: {' '.join(cmd)}", flush=True)
+    t0 = time.time()
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"{label} timed out after {timeout}s")
+
+    elapsed = time.time() - t0
+    print(f"[harness] {label} completed in {elapsed:.1f}s (exit={result.returncode})", flush=True)
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{label} failed (exit {result.returncode}):\n"
+            f"STDOUT: {result.stdout[-2000:]}\n"
+            f"STDERR: {result.stderr[-2000:]}"
+        )
+
+    # Parse JSON output
+    # ktrdr --json outputs: {"operation_type": "...", "results": {...}}
+    stdout = result.stdout.strip()
+    if not stdout:
+        raise RuntimeError(
+            f"{label} produced no output. "
+            f"STDERR: {result.stderr[-1000:]}"
+        )
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"{label} output is not valid JSON: {e}\n"
+            f"Raw output: {stdout[:2000]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main experiment
+# ---------------------------------------------------------------------------
+
+def run_experiment() -> float:
+    """
+    Full experiment pipeline:
+      1. Train on TRAIN_START → TRAIN_END
+      2. Backtest on VAL_START → VAL_END with the trained model
+      3. Return Sharpe ratio (higher = better)
+
+    Raises RuntimeError on any failure (crash, timeout, bad output).
+    """
+    # --- Train ---
+    train_result = run_ktrdr(
+        [
+            "train", STRATEGY_NAME,
+            "--start", TRAIN_START,
+            "--end", TRAIN_END,
+            "--validation-split", VALIDATION_SPLIT,
+            "--follow",
+        ],
+        timeout=MAX_TRAIN_SECONDS,
+        label="train",
+    )
+
+    results = train_result.get("results", {})
+    model_path = results.get("model_path")
+    if not model_path:
+        raise RuntimeError(
+            f"Training completed but no model_path in results. "
+            f"Got: {json.dumps(results, indent=2)}"
+        )
+
+    print(f"[harness] Model: {model_path}", flush=True)
+
+    # --- Backtest on validation window ---
+    backtest_result = run_ktrdr(
+        [
+            "backtest", STRATEGY_NAME,
+            "--start", VAL_START,
+            "--end", VAL_END,
+            "--model-path", model_path,
+            "--commission", COMMISSION,
+            "--slippage", SLIPPAGE,
+            "--follow",
+        ],
+        timeout=MAX_BACKTEST_SECONDS,
+        label="backtest(val)",
+    )
+
+    bt_results = backtest_result.get("results", {})
+    sharpe = bt_results.get("sharpe_ratio")
+
+    if sharpe is None:
+        raise RuntimeError(
+            f"Backtest completed but no sharpe_ratio in results. "
+            f"Got: {json.dumps(bt_results, indent=2)}"
+        )
+
+    return float(sharpe)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print(f"[harness] ktrdr-autoresearch", flush=True)
+    print(f"[harness] Strategy: {STRATEGY_NAME}", flush=True)
+    print(f"[harness] Train:    {TRAIN_START} → {TRAIN_END}", flush=True)
+    print(f"[harness] Val:      {VAL_START} → {VAL_END}", flush=True)
+    print(flush=True)
+
+    try:
+        sharpe = run_experiment()
+        print(flush=True)
+        print("---")
+        print(f"val_sharpe: {sharpe:.6f}")
+        sys.exit(0)
+
+    except subprocess.TimeoutExpired:
+        print("\n[harness] TIMEOUT — exceeded time budget", file=sys.stderr)
+        sys.exit(2)
+
+    except RuntimeError as e:
+        print(f"\n[harness] CRASH — {e}", file=sys.stderr)
+        sys.exit(1)

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -1,0 +1,128 @@
+# ktrdr-autoresearch
+
+You are an autonomous trading strategy researcher. Your job is to improve `strategies/autoresearch.yaml` by running experiments overnight and measuring the result.
+
+## Prerequisites (verify before starting)
+
+1. ktrdr backend is running: `curl http://localhost:8000/api/v1/health` returns 200
+2. Training worker is registered: `uv run ktrdr workers` shows at least one training worker
+3. Backtest worker is registered: `uv run ktrdr workers` shows at least one backtest worker
+4. Historical data exists for the strategy's symbol (EURUSD, 1h): `uv run ktrdr data show EURUSD 1h`
+
+## Setup for a new run
+
+1. **Agree on a run tag**: propose based on today's date (e.g. `mar11`). Branch `autoresearch/<tag>` must not exist.
+2. **Create the branch**: `git checkout -b autoresearch/<tag>` from main.
+3. **Read the in-scope files**:
+   - `autoresearch/program.md` — this file
+   - `autoresearch/harness.py` — fixed harness, do not modify
+   - `strategies/autoresearch.yaml` — the file you modify
+4. **Initialize results.tsv**: create with the header row (see format below).
+5. **First run = baseline**: run `python autoresearch/harness.py > run.log 2>&1` unmodified to establish the baseline Sharpe.
+6. Confirm setup and begin the loop.
+
+## What you are optimizing
+
+**Goal: maximize `val_sharpe`** — the Sharpe ratio on the validation window.
+
+- Training: 2020-01-01 → 2023-12-31 (train and validate your model here)
+- Validation: 2024-01-01 → 2024-12-31 ← **your metric comes from here**
+- Test: 2025+ — **does not exist for you, never use it**
+
+## What you CAN modify
+
+**`strategies/autoresearch.yaml` is your only editable file.** Everything inside is fair game:
+
+- **Indicators**: add/remove/change parameters (RSI period, MACD windows, ATR multiplier, etc.)
+- **Fuzzy membership functions**: reshape boundaries (triangular, trapezoidal, Gaussian, sigmoidal)
+- **Neural network architecture**: hidden layers, sizes, dropout, activation
+- **Training hyperparameters**: learning rate, batch size, epochs, validation split
+- **Decision thresholds**: confidence cutoffs for buy/sell signals
+- **Feature combinations**: which fuzzy outputs feed the NN
+- **Labeling strategy**: zigzag vs forward_return, threshold values
+
+## What you CANNOT modify
+
+- `autoresearch/harness.py` — fixed
+- The training/validation date windows
+- The commission (0.1%) and slippage (0.05%) assumptions — these are realistic, not negotiable
+
+## Running an experiment
+
+```bash
+# From the ktrdr root directory
+python autoresearch/harness.py > run.log 2>&1
+
+# Check result
+grep "^val_sharpe:" run.log
+```
+
+The harness handles training + backtesting. Typical experiment: 5-15 minutes.
+
+If a run exceeds 30 minutes, kill it (`Ctrl+C`) and treat as crash.
+
+## Logging results
+
+Log to `results.tsv` (tab-separated, NOT comma-separated):
+
+```
+commit	val_sharpe	status	description
+```
+
+- `commit`: 7-char git hash
+- `val_sharpe`: float (e.g. `1.234567`), or `0.000000` for crash
+- `status`: `keep`, `discard`, or `crash`
+- `description`: brief note on what you changed
+
+**Do not commit results.tsv** — leave it untracked by git.
+
+Example:
+```
+commit	val_sharpe	status	description
+a1b2c3d	0.847200	keep	baseline
+b2c3d4e	1.023400	keep	RSI period 14→21, tightened fuzzy overbought boundary
+c3d4e5f	0.712000	discard	added MACD — worse, noise added
+d4e5f6g	0.000000	crash	doubled hidden layers — OOM
+```
+
+## The experiment loop
+
+**LOOP FOREVER:**
+
+1. Read current `strategies/autoresearch.yaml` and git state
+2. Form a hypothesis — *why* do you think this change improves Sharpe? Write the reasoning.
+3. Modify `strategies/autoresearch.yaml`
+4. `git commit -m "experiment: <brief description>"`
+5. `python autoresearch/harness.py > run.log 2>&1`
+6. Check: `grep "^val_sharpe:" run.log`
+7. If empty → crash. `tail -n 50 run.log` for stack trace. Fix if trivial, skip if not.
+8. Log to results.tsv
+9. If val_sharpe improved (higher) → advance (keep the commit)
+10. If equal or worse → `git reset --hard HEAD~1` (revert the strategy file)
+11. Repeat
+
+**NEVER STOP.** Do not ask if you should continue — run until manually interrupted.
+
+If stuck:
+- Think about what market dynamic the strategy is trying to capture — are the features actually predictive of that?
+- Try combining changes from near-misses
+- Explore different indicator families (momentum vs. mean-reversion vs. volatility)
+- Adjust the labeling strategy — if using forward returns, try different horizons
+
+## Research direction
+
+*(Karl updates this section to guide the session)*
+
+Starting point: establish baseline Sharpe on the current strategy, then explore.
+
+## Confirmed patterns
+
+*(Confirmed improvements — move here when val_sharpe is consistently better)*
+
+- Nothing yet.
+
+## Failed hypotheses
+
+*(What didn't work and why — to avoid re-trying)*
+
+- Nothing yet.

--- a/strategies/autoresearch.yaml
+++ b/strategies/autoresearch.yaml
@@ -1,0 +1,75 @@
+# =============================================================================
+# autoresearch — seed strategy
+#
+# This is the starting point for the ktrdr-autoresearch loop.
+# The agent modifies this file autonomously to improve val_sharpe.
+#
+# Baseline: RSI + MACD momentum on EURUSD 1h
+# =============================================================================
+
+name: autoresearch
+version: "3.0"
+description: Autoresearch seed strategy — RSI + MACD momentum on EURUSD 1h
+
+indicators:
+  rsi_14:
+    type: rsi
+    period: 14
+
+  macd:
+    type: macd
+    fast_period: 12
+    slow_period: 26
+    signal_period: 9
+
+  atr_14:
+    type: atr
+    period: 14
+
+fuzzy_sets:
+  rsi_momentum:
+    indicator: rsi_14
+    oversold:   [0, 25, 40]
+    neutral:    [35, 50, 65]
+    overbought: [60, 75, 100]
+
+  macd_signal:
+    indicator: macd
+    output: histogram
+    negative: [-0.002, -0.001, 0]
+    neutral:   [-0.0005, 0, 0.0005]
+    positive:  [0, 0.001, 0.002]
+
+nn_inputs:
+  - fuzzy_set: rsi_momentum
+    timeframes: ["1h"]
+  - fuzzy_set: macd_signal
+    timeframes: ["1h"]
+
+model:
+  type: mlp
+  architecture:
+    hidden_layers: [64, 32]
+    dropout: 0.3
+
+decisions:
+  output_format: classification
+  thresholds:
+    buy:  0.6
+    sell: 0.6
+
+training:
+  epochs: 50
+  batch_size: 64
+  learning_rate: 0.001
+  optimizer: adam
+  loss_function: cross_entropy
+
+training_data:
+  symbols:
+    mode: single
+    symbol: EURUSD
+  timeframes:
+    mode: single
+    timeframe: "1h"
+  history_required: 200


### PR DESCRIPTION
## Summary

Adds an autoresearch framework for ktrdr, inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch).

The idea: point a Claude session at `autoresearch/program.md`, let it run overnight, wake up to a log of experiments and (hopefully) a better strategy.

**How it works:**
- `autoresearch/harness.py` — fixed experiment harness. Trains on 2020–2023, backtests on 2024 val window, returns a single metric: Sharpe ratio with realistic commission + slippage. **Never modified by the agent.**
- `strategies/autoresearch.yaml` — seed strategy (RSI + MACD on EURUSD 1h). **The only file the agent edits.**
- `autoresearch/program.md` — agent instructions: setup, loop protocol, what's editable, logging format, NEVER STOP rule.

**Experiment loop:**
1. Agent reads strategy → forms hypothesis → modifies YAML → commits
2. Runs `python autoresearch/harness.py` → checks `val_sharpe`
3. Keeps or `git reset` → logs to `results.tsv` → repeats forever

**Data windows:**
- Train: 2020–2023 (agent trains against this)
- Val: 2024 (single metric, Sharpe)
- Test: 2025+ (locked, never seen by agent)

## Test plan

- [ ] Verify `ktrdr train autoresearch --start ... --follow` works end-to-end
- [ ] Verify `ktrdr backtest autoresearch --model-path ... --follow` returns Sharpe in JSON
- [ ] Run `python autoresearch/harness.py` manually to confirm baseline Sharpe
- [ ] Let agent run a short session (2-3 experiments) and confirm loop mechanics

🤖 Generated with [Lux](https://github.com/lux-pit-ai) + Claude Code