### PR TITLE
feat(M3): H_003 experiment — LSTM temporal signal confirmed, not yet profitable

### DIFF
--- a/docs/designs/temporal-signal-models/implementation/HANDOFF_M3.md
+++ b/docs/designs/temporal-signal-models/implementation/HANDOFF_M3.md
@@ -9,7 +9,7 @@
 - Only difference: `model.type: mlp` vs `model.type: lstm` (sequence_length=20, hidden_size=64, 2 layers)
 - Training: EURUSD 5m+1h, 2015-01-01 to 2020-12-31 (6 years)
 - Backtest: EURUSD, 2021-01-01 to 2025-01-01 (4 years out-of-sample)
-- 300 epochs, batch_size=128, focal loss, gradient clip, LR scheduler, early stopping patience=25
+- 300 epochs, batch_size=128, focal loss. Note: gradient_clip, lr_scheduler, and early_stopping were configured in strategy YAML but LocalTrainingOrchestrator does not propagate these to ModelTrainer — both models ran all 300 epochs without early stopping or LR scheduling. This makes the comparison fair (same epoch count) but means neither model benefited from these features.
 
 ## Training Results
 

--- a/strategies/experiment_h003_lstm.yaml
+++ b/strategies/experiment_h003_lstm.yaml
@@ -121,10 +121,11 @@ decisions:
 training:
   labels:
     source: triple_barrier
-    profit_target_atr: 2.0
-    stop_loss_atr: 1.5
-    max_holding_bars: 24
-    atr_period: 14
+    pt_multiplier: 2.0
+    sl_multiplier: 1.5
+    max_holding_period: 24
+    vol_span: 14
+    vol_method: atr
   loss: focal
   focal_gamma: 2.0
   epochs: 300

--- a/strategies/experiment_h003_mlp.yaml
+++ b/strategies/experiment_h003_mlp.yaml
@@ -3,7 +3,7 @@ version: "3.0"
 description: >
   H_003 experiment — MLP baseline. Identical indicators, fuzzy sets, nn_inputs,
   labels, and training config as experiment_h003_lstm. Only model.type differs.
-  Train 2008-2020, backtest 2021-2025.
+  Train 2015-2020, backtest 2021-2025.
 
 training_data:
   symbols:
@@ -119,10 +119,11 @@ decisions:
 training:
   labels:
     source: triple_barrier
-    profit_target_atr: 2.0
-    stop_loss_atr: 1.5
-    max_holding_bars: 24
-    atr_period: 14
+    pt_multiplier: 2.0
+    sl_multiplier: 1.5
+    max_holding_period: 24
+    vol_span: 14
+    vol_method: atr
   loss: focal
   focal_gamma: 2.0
   epochs: 300


### PR DESCRIPTION
## Summary

Definitive comparison experiment answering hypothesis H_003: do temporal patterns in standard indicators carry predictive signal that point-in-time values don't?

**Answer: Yes, confirmed.** But the signal doesn't cover transaction costs yet.

### Experiment Design
- Two identical strategies (same indicators, fuzzy sets, labels, training config)
- Only difference: `model.type: mlp` vs `model.type: lstm`
- Train: EURUSD 5m+1h, 2015-2020 (6 years)
- Backtest: 2021-2025 (4 years out-of-sample)

### Results

**Training:**
| Metric | MLP | LSTM |
|--------|-----|------|
| Train Loss | 0.1133 (flat) | 0.1038 (-8.4%) |
| Val Accuracy | ~35% (random) | **61%** |
| Learning? | No | Yes |

**Backtest (4 years OOS):**
| Metric | MLP | LSTM |
|--------|-----|------|
| Trades | 0 | 289 |
| Return | 0.00% | -0.21% |
| Win Rate | N/A | 25% |
| Sharpe | N/A | -0.75 |

### Significance
- MLP on standard indicators = completely dead (confirmed from M1-M5)
- LSTM on same indicators = finds temporal patterns, produces non-trivial predictions
- Gap between val accuracy (61%) and backtest profitability remains
- Standard indicators + LSTM = necessary but not sufficient

### Files
- `strategies/experiment_h003_mlp.yaml` — MLP experiment config
- `strategies/experiment_h003_lstm.yaml` — LSTM experiment config
- `docs/designs/temporal-signal-models/implementation/HANDOFF_M3.md` — full analysis

## Test plan
- [x] MLP trained 300 epochs on 6 years of data
- [x] LSTM trained 300 epochs on 6 years of data
- [x] Both backtested on identical 4-year OOS window
- [x] Results documented in HANDOFF_M3.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)