### PR TITLE
feat: M3 shared observability — remove per-slot Jaeger/Grafana/Prometheus

### DIFF
--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -10,11 +10,11 @@
 # =============================================================================
 # SECRETS MANAGEMENT
 # =============================================================================
-# Secrets (KTRDR_DB_PASSWORD, KTRDR_AUTH_JWT_SECRET, ANTHROPIC_API_KEY, GF_ADMIN_PASSWORD)
+# Secrets (KTRDR_DB_PASSWORD, KTRDR_AUTH_JWT_SECRET, ANTHROPIC_API_KEY)
 # are fetched from 1Password at startup by 'ktrdr sandbox up'.
 #
 # 1Password item: ktrdr-sandbox-dev
-# Required fields: db_password, jwt_secret, anthropic_api_key, grafana_password
+# Required fields: db_password, jwt_secret, anthropic_api_key
 #
 # The defaults below are INSECURE fallbacks for --no-secrets mode only.
 # They allow the stack to start for CI/testing but should never be used
@@ -24,9 +24,11 @@
 # PORT VARIABLES
 # =============================================================================
 # All ports are parameterized with defaults matching the main docker-compose.yml.
-#   KTRDR_API_PORT, KTRDR_DB_PORT, KTRDR_GRAFANA_PORT,
-#   KTRDR_JAEGER_UI_PORT, KTRDR_JAEGER_OTLP_GRPC_PORT, KTRDR_JAEGER_OTLP_HTTP_PORT,
-#   KTRDR_PROMETHEUS_PORT, KTRDR_WORKER_PORT_1-4
+#   KTRDR_API_PORT, KTRDR_DB_PORT, KTRDR_WORKER_PORT_1-4
+#
+# Observability (Jaeger, Grafana, Prometheus) runs as a shared stack via devops-ai.
+# Start with: kinfra observability up
+# Jaeger UI: http://localhost:46686 | Grafana: http://localhost:43000
 #
 # Shared Data Variables (defaults to local ./data, ./models, ./strategies):
 #   KTRDR_DATA_DIR, KTRDR_MODELS_DIR, KTRDR_STRATEGIES_DIR
@@ -103,8 +105,8 @@ services:
       - DATABASE_URL=postgresql://${KTRDR_DB_USER:-ktrdr}:${KTRDR_DB_PASSWORD:-localdev}@db:5432/${KTRDR_DB_NAME:-ktrdr}
       # Backend API URL (used by workers and agents to connect to backend)
       - KTRDR_API_CLIENT_BASE_URL=http://backend:8000/api/v1
-      # Observability
-      - KTRDR_OTEL_OTLP_ENDPOINT=http://jaeger:4317
+      # Observability (shared stack via devops-ai-observability network)
+      - KTRDR_OTEL_OTLP_ENDPOINT=http://devops-ai-jaeger:4317
       # Checkpointing
       - KTRDR_CHECKPOINT_DIR=/app/data/checkpoints
       # IB Host Service (runs natively on Mac)
@@ -130,8 +132,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      jaeger:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health"]
       interval: 30s
@@ -140,79 +140,7 @@ services:
       start_period: 30s
     networks:
       - ktrdr-network
-
-  # Jaeger - Distributed tracing
-  jaeger:
-    image: jaegertracing/all-in-one:1.53
-    restart: unless-stopped
-    ports:
-      - "${KTRDR_JAEGER_UI_PORT:-16686}:16686"
-      - "${KTRDR_JAEGER_OTLP_GRPC_PORT:-4317}:4317"
-      - "${KTRDR_JAEGER_OTLP_HTTP_PORT:-4318}:4318"
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
-      - LOG_LEVEL=info
-    networks:
-      - ktrdr-network
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:16686"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
-
-  # Prometheus - Metrics collection
-  prometheus:
-    image: prom/prometheus:latest
-    restart: unless-stopped
-    ports:
-      - "${KTRDR_PROMETHEUS_PORT:-9090}:9090"
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--storage.tsdb.retention.time=7d'
-      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-      - '--web.console.templates=/usr/share/prometheus/consoles'
-    networks:
-      - ktrdr-network
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
-
-  # Grafana - Dashboards
-  grafana:
-    image: grafana/grafana:latest
-    restart: unless-stopped
-    ports:
-      - "${KTRDR_GRAFANA_PORT:-3000}:3000"
-    environment:
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_SECURITY_ALLOW_EMBEDDING=true
-      # INSECURE default - use 1Password via 'ktrdr sandbox up'
-      - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:-admin}
-    volumes:
-      - ./deploy/shared/grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
-      - ./deploy/shared/grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
-      - ./deploy/shared/grafana/dashboards:/var/lib/grafana/dashboards:ro
-      - grafana_data:/var/lib/grafana
-    depends_on:
-      - prometheus
-      - jaeger
-    networks:
-      - ktrdr-network
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+      - devops-ai-observability
 
   # Backtest Worker 1
   # Workers need matching internal/external ports for registration
@@ -245,7 +173,7 @@ services:
       - WORKER_TYPE=backtesting
       - KTRDR_WORKER_PORT=5003
       - KTRDR_WORKER_PUBLIC_BASE_URL=http://backtest-worker-1:5003
-      - KTRDR_OTEL_OTLP_ENDPOINT=http://jaeger:4317
+      - KTRDR_OTEL_OTLP_ENDPOINT=http://devops-ai-jaeger:4317
       - KTRDR_CHECKPOINT_DIR=/app/data/checkpoints
       - KTRDR_DB_HOST=db
       - KTRDR_DB_PORT=5432
@@ -262,6 +190,7 @@ services:
       start_period: 30s
     networks:
       - ktrdr-network
+      - devops-ai-observability
     depends_on:
       db:
         condition: service_healthy
@@ -298,7 +227,7 @@ services:
       - WORKER_TYPE=backtesting
       - KTRDR_WORKER_PORT=5004
       - KTRDR_WORKER_PUBLIC_BASE_URL=http://backtest-worker-2:5004
-      - KTRDR_OTEL_OTLP_ENDPOINT=http://jaeger:4317
+      - KTRDR_OTEL_OTLP_ENDPOINT=http://devops-ai-jaeger:4317
       - KTRDR_CHECKPOINT_DIR=/app/data/checkpoints
       - KTRDR_DB_HOST=db
       - KTRDR_DB_PORT=5432
@@ -315,6 +244,7 @@ services:
       start_period: 30s
     networks:
       - ktrdr-network
+      - devops-ai-observability
     depends_on:
       db:
         condition: service_healthy
@@ -351,7 +281,7 @@ services:
       - WORKER_TYPE=training
       - KTRDR_WORKER_PORT=5005
       - KTRDR_WORKER_PUBLIC_BASE_URL=http://training-worker-1:5005
-      - KTRDR_OTEL_OTLP_ENDPOINT=http://jaeger:4317
+      - KTRDR_OTEL_OTLP_ENDPOINT=http://devops-ai-jaeger:4317
       - KTRDR_CHECKPOINT_DIR=/app/data/checkpoints
       - KTRDR_DB_HOST=db
       - KTRDR_DB_PORT=5432
@@ -369,6 +299,7 @@ services:
       start_period: 30s
     networks:
       - ktrdr-network
+      - devops-ai-observability
     depends_on:
       db:
         condition: service_healthy
@@ -405,7 +336,7 @@ services:
       - WORKER_TYPE=training
       - KTRDR_WORKER_PORT=5006
       - KTRDR_WORKER_PUBLIC_BASE_URL=http://training-worker-2:5006
-      - KTRDR_OTEL_OTLP_ENDPOINT=http://jaeger:4317
+      - KTRDR_OTEL_OTLP_ENDPOINT=http://devops-ai-jaeger:4317
       - KTRDR_CHECKPOINT_DIR=/app/data/checkpoints
       - KTRDR_DB_HOST=db
       - KTRDR_DB_PORT=5432
@@ -423,6 +354,7 @@ services:
       start_period: 30s
     networks:
       - ktrdr-network
+      - devops-ai-observability
     depends_on:
       db:
         condition: service_healthy
@@ -452,7 +384,7 @@ services:
       - KTRDR_LOG_LEVEL=INFO
       - PYTHONPATH=/app:/mcp       # Include both /app (for ktrdr) and /mcp (for src)
       - KTRDR_API_CLIENT_BASE_URL=http://backend:8000/api/v1
-      - KTRDR_OTEL_OTLP_ENDPOINT=http://jaeger:4317
+      - KTRDR_OTEL_OTLP_ENDPOINT=http://devops-ai-jaeger:4317
     working_dir: /mcp
     stdin_open: true               # Required for stdio MCP transport
     networks:
@@ -514,6 +446,7 @@ services:
       start_period: 45s
     networks:
       - ktrdr-network
+      - devops-ai-observability
     depends_on:
       backend:
         condition: service_healthy
@@ -562,6 +495,7 @@ services:
       start_period: 45s
     networks:
       - ktrdr-network
+      - devops-ai-observability
     depends_on:
       backend:
         condition: service_healthy
@@ -612,7 +546,7 @@ services:
   #     - WORKER_TYPE=backtesting
   #     - KTRDR_WORKER_PORT=5007
   #     - KTRDR_WORKER_PUBLIC_BASE_URL=http://backtest-worker-3:5007
-  #     - KTRDR_OTEL_OTLP_ENDPOINT=http://jaeger:4317
+  #     - KTRDR_OTEL_OTLP_ENDPOINT=http://devops-ai-jaeger:4317
   #     - KTRDR_CHECKPOINT_DIR=/app/data/checkpoints
   #     - KTRDR_DB_HOST=db
   #     - KTRDR_DB_PORT=5432
@@ -666,7 +600,7 @@ services:
   #     - WORKER_TYPE=backtesting
   #     - KTRDR_WORKER_PORT=5008
   #     - KTRDR_WORKER_PUBLIC_BASE_URL=http://backtest-worker-4:5008
-  #     - KTRDR_OTEL_OTLP_ENDPOINT=http://jaeger:4317
+  #     - KTRDR_OTEL_OTLP_ENDPOINT=http://devops-ai-jaeger:4317
   #     - KTRDR_CHECKPOINT_DIR=/app/data/checkpoints
   #     - KTRDR_DB_HOST=db
   #     - KTRDR_DB_PORT=5432
@@ -720,7 +654,7 @@ services:
   #     - WORKER_TYPE=training
   #     - KTRDR_WORKER_PORT=5009
   #     - KTRDR_WORKER_PUBLIC_BASE_URL=http://training-worker-3:5009
-  #     - KTRDR_OTEL_OTLP_ENDPOINT=http://jaeger:4317
+  #     - KTRDR_OTEL_OTLP_ENDPOINT=http://devops-ai-jaeger:4317
   #     - KTRDR_CHECKPOINT_DIR=/app/data/checkpoints
   #     - KTRDR_DB_HOST=db
   #     - KTRDR_DB_PORT=5432
@@ -774,7 +708,7 @@ services:
   #     - WORKER_TYPE=training
   #     - KTRDR_WORKER_PORT=5010
   #     - KTRDR_WORKER_PUBLIC_BASE_URL=http://training-worker-4:5010
-  #     - KTRDR_OTEL_OTLP_ENDPOINT=http://jaeger:4317
+  #     - KTRDR_OTEL_OTLP_ENDPOINT=http://devops-ai-jaeger:4317
   #     - KTRDR_CHECKPOINT_DIR=/app/data/checkpoints
   #     - KTRDR_DB_HOST=db
   #     - KTRDR_DB_PORT=5432
@@ -801,11 +735,12 @@ services:
 networks:
   ktrdr-network:
     driver: bridge
+  devops-ai-observability:
+    external: true
+    name: devops-ai-observability
 
 volumes:
   postgres_data:
-  prometheus_data:
-  grafana_data:
   pip-cache:
   uv-cache:
   # Named volume for Claude Code auth (shared across agent containers)

--- a/docs/designs/devops-ai-migration/implementation/HANDOFF_devops-migration.md
+++ b/docs/designs/devops-ai-migration/implementation/HANDOFF_devops-migration.md
@@ -40,3 +40,23 @@
 
 ### Gotchas
 - `backtesting/` and `backtest/` are separate categories (2 integration tests vs 16 core tests). Not merged — they serve different purposes.
+
+## M3: Shared Observability
+
+### Compose changes
+- Removed jaeger, prometheus, grafana services (~72 lines) + their named volumes
+- Removed backend's depends_on jaeger
+- Added `devops-ai-observability` external network to 7 services (backend + 4 workers + 2 agents)
+- Updated all 10 OTEL endpoints to `http://devops-ai-jaeger:4317`
+
+### sandbox_ports.py
+- Removed 5 fields: grafana, jaeger_ui, jaeger_otlp_grpc, jaeger_otlp_http, prometheus
+- 6 ports per slot (down from 11)
+
+### Port reference cleanup
+- Fixed ~20 display strings to show shared ports (43000, 46686, 49090) with "(shared)"
+- CLI telemetry endpoint updated to shared OTLP port 44317
+
+### Gotchas
+- mypy has 59 pre-existing errors (same on main)
+- GF_ADMIN_PASSWORD secret no longer needed (grafana is shared)

--- a/ktrdr/cli/__init__.py
+++ b/ktrdr/cli/__init__.py
@@ -61,10 +61,10 @@ def _derive_otlp_endpoint_from_url(api_url: str | None) -> str:
     try:
         from ktrdr.cli.sandbox_detect import get_sandbox_var
 
-        port = get_sandbox_var("KTRDR_OTLP_GRPC_PORT", "4317")
-        return f"http://localhost:{port}"
+        # Shared observability stack via devops-ai on fixed port
+        return "http://localhost:44317"
     except Exception:
-        return "http://localhost:4317"
+        return "http://localhost:44317"
 
 
 def reconfigure_telemetry_for_url(api_url: str) -> None:

--- a/ktrdr/cli/instance_core.py
+++ b/ktrdr/cli/instance_core.py
@@ -456,12 +456,9 @@ def start_instance(
         console.print("[green]Startability Gate: PASSED[/green]")
         console.print(f"\nInstance ready ({result.duration_seconds:.1f}s):")
         console.print(f"  API: http://localhost:{api_port}/api/v1/docs")
-        console.print(
-            f"  Grafana: http://localhost:{env.get('KTRDR_GRAFANA_PORT', 3000)}"
-        )
-        console.print(
-            f"  Jaeger: http://localhost:{env.get('KTRDR_JAEGER_UI_PORT', 16686)}"
-        )
+        # Shared observability ports (devops-ai)
+        console.print("  Grafana: http://localhost:43000 (shared)")
+        console.print("  Jaeger: http://localhost:46686 (shared)")
         return 0
     else:
         error_console.print("[red]Startability Gate: FAILED[/red]")

--- a/ktrdr/cli/kinfra/local_prod.py
+++ b/ktrdr/cli/kinfra/local_prod.py
@@ -190,7 +190,7 @@ def init() -> None:
     console.print(f"  Location: {cwd}")
     console.print(f"  Port slot: {LOCAL_PROD_SLOT} (standard ports)")
     console.print(f"  API: http://localhost:{ports.backend}")
-    console.print(f"  Grafana: http://localhost:{ports.grafana}")
+    console.print("  Grafana: http://localhost:43000 (shared)")  # Shared observability
     console.print("\nRun 'ktrdr local-prod up' to start")
 
 
@@ -324,16 +324,14 @@ def status() -> None:
     # Service URLs
     api_port = env.get("KTRDR_API_PORT", "8000")
     db_port = env.get("KTRDR_DB_PORT", "5432")
-    grafana_port = env.get("KTRDR_GRAFANA_PORT", "3000")
-    jaeger_port = env.get("KTRDR_JAEGER_UI_PORT", "16686")
-
+    # Shared observability ports (devops-ai)
     console.print()
     console.print("[bold]Services:[/bold]")
     console.print(f"  Backend:    http://localhost:{api_port}")
     console.print(f"  API Docs:   http://localhost:{api_port}/api/v1/docs")
     console.print(f"  Database:   localhost:{db_port}")
-    console.print(f"  Grafana:    http://localhost:{grafana_port}")
-    console.print(f"  Jaeger:     http://localhost:{jaeger_port}")
+    console.print("  Grafana:    http://localhost:43000 (shared)")
+    console.print("  Jaeger:     http://localhost:46686 (shared)")
 
     console.print()
     console.print("[bold]Workers:[/bold]")

--- a/ktrdr/cli/kinfra/sandbox.py
+++ b/ktrdr/cli/kinfra/sandbox.py
@@ -444,7 +444,7 @@ def create(
     console.print(f"  Location: {worktree_path}")
     console.print(f"  Port slot: {slot}")
     console.print(f"  API: http://localhost:{ports.backend}")
-    console.print(f"  Grafana: http://localhost:{ports.grafana}")
+    console.print("  Grafana: http://localhost:43000 (shared)")  # Shared observability
     console.print(f"\nRun 'cd {worktree_path} && ktrdr sandbox up' to start")
 
 
@@ -552,7 +552,7 @@ def init(
     console.print(f"\n[green]Initialized sandbox:[/green] {instance_id}")
     console.print(f"  Port slot: {slot}")
     console.print(f"  API: http://localhost:{ports.backend}")
-    console.print(f"  Grafana: http://localhost:{ports.grafana}")
+    console.print("  Grafana: http://localhost:43000 (shared)")  # Shared observability
     console.print("\nRun 'ktrdr sandbox up' to start")
 
 
@@ -837,12 +837,9 @@ def up(
         console.print("[green]Startability Gate: PASSED[/green]")
         console.print(f"\nInstance ready ({result.duration_seconds:.1f}s):")
         console.print(f"  API: http://localhost:{api_port}/api/v1/docs")
-        console.print(
-            f"  Grafana: http://localhost:{env.get('KTRDR_GRAFANA_PORT', 3000)}"
-        )
-        console.print(
-            f"  Jaeger: http://localhost:{env.get('KTRDR_JAEGER_UI_PORT', 16686)}"
-        )
+        # Shared observability ports (devops-ai)
+        console.print("  Grafana: http://localhost:43000 (shared)")
+        console.print("  Jaeger: http://localhost:46686 (shared)")
     else:
         error_console.print("[red]Startability Gate: FAILED[/red]")
         error_console.print("\nCheck logs with: ktrdr sandbox logs")
@@ -1168,17 +1165,14 @@ def status() -> None:
     # Service URLs
     api_port = env.get("KTRDR_API_PORT", "8000")
     db_port = env.get("KTRDR_DB_PORT", "5432")
-    grafana_port = env.get("KTRDR_GRAFANA_PORT", "3000")
-    jaeger_port = env.get("KTRDR_JAEGER_UI_PORT", "16686")
-    prometheus_port = env.get("KTRDR_PROMETHEUS_PORT", "9090")
-
+    # Shared observability ports (devops-ai)
     console.print("[bold]Services:[/bold]")
     console.print(f"  Backend:    http://localhost:{api_port}")
     console.print(f"  API Docs:   http://localhost:{api_port}/api/v1/docs")
     console.print(f"  Database:   localhost:{db_port}")
-    console.print(f"  Grafana:    http://localhost:{grafana_port}")
-    console.print(f"  Jaeger:     http://localhost:{jaeger_port}")
-    console.print(f"  Prometheus: http://localhost:{prometheus_port}")
+    console.print("  Grafana:    http://localhost:43000 (shared)")
+    console.print("  Jaeger:     http://localhost:46686 (shared)")
+    console.print("  Prometheus: http://localhost:49090 (shared)")
 
     console.print()
     console.print("[bold]Workers:[/bold]")
@@ -1470,9 +1464,6 @@ def _update_registry_with_slots(base_path: Path) -> None:
         ports = {
             "api": allocation.backend,
             "db": allocation.db,
-            "grafana": allocation.grafana,
-            "jaeger_ui": allocation.jaeger_ui,
-            "prometheus": allocation.prometheus,
         }
 
         if slot_key in registry.slots:

--- a/ktrdr/cli/local_prod.py
+++ b/ktrdr/cli/local_prod.py
@@ -203,7 +203,7 @@ def init() -> None:
     console.print(f"  Location: {cwd}")
     console.print(f"  Port slot: {LOCAL_PROD_SLOT} (standard ports)")
     console.print(f"  API: http://localhost:{ports.backend}")
-    console.print(f"  Grafana: http://localhost:{ports.grafana}")
+    console.print("  Grafana: http://localhost:43000 (shared)")  # Shared observability
     console.print("\nRun 'ktrdr local-prod up' to start")
 
 
@@ -337,16 +337,14 @@ def status() -> None:
     # Service URLs
     api_port = env.get("KTRDR_API_PORT", "8000")
     db_port = env.get("KTRDR_DB_PORT", "5432")
-    grafana_port = env.get("KTRDR_GRAFANA_PORT", "3000")
-    jaeger_port = env.get("KTRDR_JAEGER_UI_PORT", "16686")
-
+    # Shared observability ports (devops-ai)
     console.print()
     console.print("[bold]Services:[/bold]")
     console.print(f"  Backend:    http://localhost:{api_port}")
     console.print(f"  API Docs:   http://localhost:{api_port}/api/v1/docs")
     console.print(f"  Database:   localhost:{db_port}")
-    console.print(f"  Grafana:    http://localhost:{grafana_port}")
-    console.print(f"  Jaeger:     http://localhost:{jaeger_port}")
+    console.print("  Grafana:    http://localhost:43000 (shared)")
+    console.print("  Jaeger:     http://localhost:46686 (shared)")
 
     console.print()
     console.print("[bold]Workers:[/bold]")

--- a/ktrdr/cli/sandbox.py
+++ b/ktrdr/cli/sandbox.py
@@ -440,7 +440,7 @@ def create(
     console.print(f"  Location: {worktree_path}")
     console.print(f"  Port slot: {slot}")
     console.print(f"  API: http://localhost:{ports.backend}")
-    console.print(f"  Grafana: http://localhost:{ports.grafana}")
+    console.print("  Grafana: http://localhost:43000 (shared)")  # Shared observability
     console.print(f"\nRun 'cd {worktree_path} && ktrdr sandbox up' to start")
 
 
@@ -548,7 +548,7 @@ def init(
     console.print(f"\n[green]Initialized sandbox:[/green] {instance_id}")
     console.print(f"  Port slot: {slot}")
     console.print(f"  API: http://localhost:{ports.backend}")
-    console.print(f"  Grafana: http://localhost:{ports.grafana}")
+    console.print("  Grafana: http://localhost:43000 (shared)")  # Shared observability
     console.print("\nRun 'ktrdr sandbox up' to start")
 
 
@@ -802,12 +802,9 @@ def up(
         console.print("[green]Startability Gate: PASSED[/green]")
         console.print(f"\nInstance ready ({result.duration_seconds:.1f}s):")
         console.print(f"  API: http://localhost:{api_port}/api/v1/docs")
-        console.print(
-            f"  Grafana: http://localhost:{env.get('KTRDR_GRAFANA_PORT', 3000)}"
-        )
-        console.print(
-            f"  Jaeger: http://localhost:{env.get('KTRDR_JAEGER_UI_PORT', 16686)}"
-        )
+        # Shared observability ports (devops-ai)
+        console.print("  Grafana: http://localhost:43000 (shared)")
+        console.print("  Jaeger: http://localhost:46686 (shared)")
     else:
         error_console.print("[red]Startability Gate: FAILED[/red]")
         error_console.print("\nCheck logs with: ktrdr sandbox logs")
@@ -1133,17 +1130,14 @@ def status() -> None:
     # Service URLs
     api_port = env.get("KTRDR_API_PORT", "8000")
     db_port = env.get("KTRDR_DB_PORT", "5432")
-    grafana_port = env.get("KTRDR_GRAFANA_PORT", "3000")
-    jaeger_port = env.get("KTRDR_JAEGER_UI_PORT", "16686")
-    prometheus_port = env.get("KTRDR_PROMETHEUS_PORT", "9090")
-
+    # Shared observability ports (devops-ai)
     console.print("[bold]Services:[/bold]")
     console.print(f"  Backend:    http://localhost:{api_port}")
     console.print(f"  API Docs:   http://localhost:{api_port}/api/v1/docs")
     console.print(f"  Database:   localhost:{db_port}")
-    console.print(f"  Grafana:    http://localhost:{grafana_port}")
-    console.print(f"  Jaeger:     http://localhost:{jaeger_port}")
-    console.print(f"  Prometheus: http://localhost:{prometheus_port}")
+    console.print("  Grafana:    http://localhost:43000 (shared)")
+    console.print("  Jaeger:     http://localhost:46686 (shared)")
+    console.print("  Prometheus: http://localhost:49090 (shared)")
 
     console.print()
     console.print("[bold]Workers:[/bold]")

--- a/ktrdr/cli/sandbox_ports.py
+++ b/ktrdr/cli/sandbox_ports.py
@@ -6,6 +6,9 @@ without port conflicts.
 
 Slot 0 uses standard development ports (8000, 5432, etc.).
 Slots 1-10 use offset ports for sandbox instances.
+
+Observability (Jaeger, Grafana, Prometheus) runs as a shared stack via
+devops-ai on fixed ports (46686, 43000, 49090) — not allocated per slot.
 """
 
 import socket
@@ -25,11 +28,6 @@ class PortAllocation:
     slot: int
     backend: int
     db: int
-    grafana: int
-    jaeger_ui: int
-    jaeger_otlp_grpc: int
-    jaeger_otlp_http: int
-    prometheus: int
     worker_ports: list[int]  # 4 worker ports
 
     def to_env_dict(self) -> dict[str, str]:
@@ -43,11 +41,6 @@ class PortAllocation:
             "SLOT_NUMBER": str(self.slot),
             "KTRDR_API_PORT": str(self.backend),
             "KTRDR_DB_PORT": str(self.db),
-            "KTRDR_GRAFANA_PORT": str(self.grafana),
-            "KTRDR_JAEGER_UI_PORT": str(self.jaeger_ui),
-            "KTRDR_OTLP_GRPC_PORT": str(self.jaeger_otlp_grpc),
-            "KTRDR_OTLP_HTTP_PORT": str(self.jaeger_otlp_http),
-            "KTRDR_PROMETHEUS_PORT": str(self.prometheus),
             "KTRDR_WORKER_PORT_1": str(self.worker_ports[0]),
             "KTRDR_WORKER_PORT_2": str(self.worker_ports[1]),
             "KTRDR_WORKER_PORT_3": str(self.worker_ports[2]),
@@ -57,16 +50,11 @@ class PortAllocation:
     def all_ports(self) -> list[int]:
         """Return all ports for conflict checking.
 
-        Returns a list of all ports (7 services + 4 workers).
+        Returns a list of all ports (2 services + 4 workers).
         """
         return [
             self.backend,
             self.db,
-            self.grafana,
-            self.jaeger_ui,
-            self.jaeger_otlp_grpc,
-            self.jaeger_otlp_http,
-            self.prometheus,
             *self.worker_ports,
         ]
 
@@ -94,11 +82,6 @@ def get_ports(slot: int) -> PortAllocation:
             slot=0,
             backend=8000,
             db=5432,
-            grafana=3000,
-            jaeger_ui=16686,
-            jaeger_otlp_grpc=4317,
-            jaeger_otlp_http=4318,
-            prometheus=9090,
             worker_ports=[5003, 5004, 5005, 5006],
         )
 
@@ -107,11 +90,6 @@ def get_ports(slot: int) -> PortAllocation:
         slot=slot,
         backend=8000 + slot,
         db=5432 + slot,
-        grafana=3000 + slot,
-        jaeger_ui=16686 + slot,
-        jaeger_otlp_grpc=4317 + slot * 10,  # 4327, 4337, ... (10-slot offset)
-        jaeger_otlp_http=4318 + slot * 10,  # 4328, 4338, ...
-        prometheus=9090 + slot,
         worker_ports=[
             5007 + (slot - 1) * 10,  # 5007, 5017, 5027, ...
             5007 + (slot - 1) * 10 + 1,  # 5008, 5018, 5028, ...

--- a/tests/unit/cli/kinfra/test_sandbox.py
+++ b/tests/unit/cli/kinfra/test_sandbox.py
@@ -330,9 +330,6 @@ class TestSlotPortRefresh:
                     "ports": {
                         "api": 8003,
                         "db": 5435,
-                        "grafana": 3003,
-                        "jaeger_ui": 16689,
-                        "prometheus": 9093,
                     },
                     "claimed_by": None,
                     "claimed_at": None,
@@ -350,9 +347,7 @@ class TestSlotPortRefresh:
         slot1_ports = updated["slots"]["1"]["ports"]
         assert slot1_ports["api"] == 8001
         assert slot1_ports["db"] == 5433
-        assert slot1_ports["grafana"] == 3001
-        assert slot1_ports["jaeger_ui"] == 16687
-        assert slot1_ports["prometheus"] == 9091
+        # Observability ports no longer allocated per slot (shared stack)
 
     def test_provision_preserves_claim_state(self, tmp_path, monkeypatch) -> None:
         """Port refresh should not disturb claimed_by or status."""
@@ -380,9 +375,6 @@ class TestSlotPortRefresh:
                     "ports": {
                         "api": 9999,
                         "db": 9998,
-                        "grafana": 9997,
-                        "jaeger_ui": 9996,
-                        "prometheus": 9995,
                     },
                     "claimed_by": "/some/worktree",
                     "claimed_at": "2026-02-16T00:00:00+00:00",

--- a/tests/unit/cli/test_sandbox_ports.py
+++ b/tests/unit/cli/test_sandbox_ports.py
@@ -3,6 +3,9 @@ Tests for the sandbox port allocation module.
 
 This module tests port slot allocation for sandbox instances,
 ensuring deterministic port mapping and conflict detection.
+
+Observability (Jaeger, Grafana, Prometheus) runs as a shared stack
+via devops-ai on fixed ports — not allocated per slot.
 """
 
 import socket
@@ -20,15 +23,9 @@ class TestPortAllocation:
 
         ports = get_ports(0)
 
-        # Standard ports from current docker-compose.yml
         assert ports.slot == 0
         assert ports.backend == 8000
         assert ports.db == 5432
-        assert ports.grafana == 3000
-        assert ports.jaeger_ui == 16686
-        assert ports.jaeger_otlp_grpc == 4317
-        assert ports.jaeger_otlp_http == 4318
-        assert ports.prometheus == 9090
         assert ports.worker_ports == [5003, 5004, 5005, 5006]
 
     def test_slot_1_returns_offset_ports(self):
@@ -40,12 +37,6 @@ class TestPortAllocation:
         assert ports.slot == 1
         assert ports.backend == 8001
         assert ports.db == 5433
-        assert ports.grafana == 3001
-        assert ports.jaeger_ui == 16687
-        # Jaeger OTLP uses 10-slot offset to avoid overlap
-        assert ports.jaeger_otlp_grpc == 4327
-        assert ports.jaeger_otlp_http == 4328
-        assert ports.prometheus == 9091
         # Worker ports for slot 1: 5007-5010 (shifted to avoid slot 0's 5003-5006)
         assert ports.worker_ports == [5007, 5008, 5009, 5010]
 
@@ -69,12 +60,6 @@ class TestPortAllocation:
         assert ports.slot == 10
         assert ports.backend == 8010
         assert ports.db == 5442
-        assert ports.grafana == 3010
-        assert ports.jaeger_ui == 16696
-        # Slot 10: 4317 + 10*10 = 4417
-        assert ports.jaeger_otlp_grpc == 4417
-        assert ports.jaeger_otlp_http == 4418
-        assert ports.prometheus == 9100
         # Worker ports for slot 10: 5007 + (10-1)*10 = 5097
         assert ports.worker_ports == [5097, 5098, 5099, 5100]
 
@@ -103,20 +88,18 @@ class TestToEnvDict:
         ports = get_ports(1)
         env = ports.to_env_dict()
 
-        # Check all required keys are present
         assert env["SLOT_NUMBER"] == "1"
         assert env["KTRDR_API_PORT"] == "8001"
         assert env["KTRDR_DB_PORT"] == "5433"
-        assert env["KTRDR_GRAFANA_PORT"] == "3001"
-        assert env["KTRDR_JAEGER_UI_PORT"] == "16687"
-        assert env["KTRDR_OTLP_GRPC_PORT"] == "4327"
-        assert env["KTRDR_OTLP_HTTP_PORT"] == "4328"
-        assert env["KTRDR_PROMETHEUS_PORT"] == "9091"
         # Slot 1 worker ports: 5007-5010 (shifted to avoid slot 0's 5003-5006)
         assert env["KTRDR_WORKER_PORT_1"] == "5007"
         assert env["KTRDR_WORKER_PORT_2"] == "5008"
         assert env["KTRDR_WORKER_PORT_3"] == "5009"
         assert env["KTRDR_WORKER_PORT_4"] == "5010"
+        # No observability ports (shared stack)
+        assert "KTRDR_GRAFANA_PORT" not in env
+        assert "KTRDR_JAEGER_UI_PORT" not in env
+        assert "KTRDR_PROMETHEUS_PORT" not in env
 
     def test_to_env_dict_all_values_are_strings(self):
         """All values in env dict should be strings."""
@@ -154,24 +137,17 @@ class TestAllPorts:
         assert all(isinstance(p, int) for p in all_ports)
 
     def test_all_ports_contains_all_services(self):
-        """all_ports() should contain all 11 ports."""
+        """all_ports() should contain all 6 ports (2 services + 4 workers)."""
         from ktrdr.cli.sandbox_ports import get_ports
 
         ports = get_ports(1)
         all_ports = ports.all_ports()
 
-        # 7 service ports + 4 worker ports = 11 total
-        assert len(all_ports) == 11
+        # 2 service ports + 4 worker ports = 6 total
+        assert len(all_ports) == 6
 
-        # Verify specific ports are included
         assert 8001 in all_ports  # backend
         assert 5433 in all_ports  # db
-        assert 3001 in all_ports  # grafana
-        assert 16687 in all_ports  # jaeger_ui
-        assert 4327 in all_ports  # jaeger_otlp_grpc
-        assert 4328 in all_ports  # jaeger_otlp_http
-        assert 9091 in all_ports  # prometheus
-        # Slot 1 worker ports: 5007-5010
         assert 5007 in all_ports  # worker 1
         assert 5008 in all_ports  # worker 2
         assert 5009 in all_ports  # worker 3
@@ -185,8 +161,6 @@ class TestPortAvailability:
         """is_port_free() returns True for unused port."""
         from ktrdr.cli.sandbox_ports import is_port_free
 
-        # Port 59999 is unlikely to be in use
-        # Using a high port to avoid conflicts
         result = is_port_free(59999)
         assert result is True
 
@@ -194,7 +168,6 @@ class TestPortAvailability:
         """is_port_free() returns False when port is in use."""
         from ktrdr.cli.sandbox_ports import is_port_free
 
-        # Bind a socket to test
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("127.0.0.1", 59998))
             s.listen(1)
@@ -206,7 +179,6 @@ class TestPortAvailability:
         """check_ports_available() returns empty list when all ports free."""
         from ktrdr.cli.sandbox_ports import check_ports_available
 
-        # Mock is_port_free to return True for all
         with patch("ktrdr.cli.sandbox_ports.is_port_free", return_value=True):
             conflicts = check_ports_available(5)
             assert conflicts == []
@@ -217,7 +189,6 @@ class TestPortAvailability:
 
         ports = get_ports(3)
 
-        # Mock: only backend port is in use
         def mock_is_port_free(port):
             return port != ports.backend
 
@@ -242,7 +213,6 @@ class TestSlotConsistency:
             ports = get_ports(slot)
             slot_ports = set(ports.all_ports())
 
-            # Check no overlap with previous slots
             overlap = all_ports_seen & slot_ports
             assert not overlap, f"Slot {slot} overlaps with previous slots: {overlap}"
 


### PR DESCRIPTION
## Summary

Remove per-slot observability services (Jaeger, Grafana, Prometheus) from ktrdr's docker-compose and connect to devops-ai's shared observability stack instead.

**Compose changes:**
- Remove 3 service definitions + 2 named volumes (~72 lines)
- Add `devops-ai-observability` external Docker network
- Connect 7 services (backend + 4 workers + 2 agents) to shared stack
- Update all OTEL endpoints: `jaeger:4317` → `devops-ai-jaeger:4317`

**Port allocation:**
- Remove 5 observability fields from PortAllocation (6 ports/slot, down from 11)
- Update ~20 display strings to show shared ports with "(shared)" suffix
- CLI telemetry → shared OTLP port 44317

**Shared stack ports (fixed, not per-slot):**
- Jaeger UI: `localhost:46686`
- Grafana: `localhost:43000`  
- Prometheus: `localhost:49090`

## Test plan

- [ ] `docker compose -f docker-compose.sandbox.yml config` validates
- [ ] Unit tests pass (36 port/sandbox tests updated)
- [ ] `make quality` lint passes (mypy has 59 pre-existing errors, unchanged)
- [ ] Start shared stack: `kinfra observability up`
- [ ] Start sandbox, verify traces appear in shared Jaeger (port 46686)
- [ ] No per-slot observability containers running

🤖 Generated with [Claude Code](https://claude.com/claude-code)