### PR TITLE
feat: squad v2 multi-turn debate — M3

### DIFF
--- a/.claude/skills/ke2e/tests/squad/m3-debate-genuine-revision.md
+++ b/.claude/skills/ke2e/tests/squad/m3-debate-genuine-revision.md
@@ -1,0 +1,936 @@
+# Test: squad/m3-debate-genuine-revision
+
+**Purpose:** Validate the Director's multi-turn debate relay: Engineer designs a strategy, Critic challenges it, Director synthesizes Critic's concern and relays to Engineer, Engineer produces a measurably revised strategy. Proves the debate loop produces genuine revision (not rubber-stamping) and that debate metadata is captured in CycleResult.
+
+**Duration:** ~20-45 minutes (1 cycle with debate adds ~5-10 min over baseline)
+
+**Category:** Squad / Conversational Orchestrator / M3
+
+**Estimated cost:** ~$3-8 (1 Director session + Engineer multi-turn + Critic + Scribe)
+
+---
+
+## Pre-Flight Checks
+
+**Required modules:**
+- [common](../../preflight/common.md) -- Docker, sandbox (slot 1, port 8001), API health
+
+**Test-specific checks:**
+
+- [ ] Sandbox running on slot 1 (port 8001)
+
+```bash
+source .env.sandbox
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:${KTRDR_API_PORT}/api/v1/health)
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "FAIL: Backend API not responding on port ${KTRDR_API_PORT} (HTTP $HTTP_CODE)"
+  exit 1
+fi
+echo "OK: Backend API healthy on port ${KTRDR_API_PORT}"
+```
+
+- [ ] KB files exist at shared dir
+
+```bash
+SHARED="$HOME/.ktrdr/shared/squad"
+MISSING=""
+for KB_FILE in knowledge/experiments.md knowledge/hypotheses.md knowledge/decisions.md knowledge/frontiers.md knowledge/synthesis.md loop/cadence.md loop/nudges.md; do
+  if [ ! -f "$SHARED/$KB_FILE" ]; then
+    MISSING="$MISSING $KB_FILE"
+  fi
+done
+
+if [ -n "$MISSING" ]; then
+  echo "FAIL: Missing KB files:$MISSING"
+  exit 1
+fi
+echo "OK: All KB files present"
+```
+
+- [ ] Claude Code CLI available
+
+```bash
+if ! which claude >/dev/null 2>&1; then
+  echo "FAIL: claude CLI not found in PATH"
+  exit 1
+fi
+echo "OK: claude CLI available at $(which claude)"
+```
+
+- [ ] Executor script exists and is executable
+
+```bash
+if [ ! -x ".squad/executor.sh" ]; then
+  echo "FAIL: .squad/executor.sh not found or not executable"
+  exit 1
+fi
+echo "OK: executor.sh exists and is executable"
+```
+
+- [ ] All 8 agent charters present (director + 7 consultants)
+
+```bash
+MISSING=""
+for AGENT in director engineer scribe quant inventor scout critic architect; do
+  if [ ! -f ".squad/agents/${AGENT}/charter.md" ]; then
+    MISSING="$MISSING $AGENT"
+  fi
+done
+
+if [ -n "$MISSING" ]; then
+  echo "FAIL: Missing charters:$MISSING"
+  exit 1
+fi
+echo "OK: All 8 agent charters present"
+```
+
+- [ ] Critic charter contains adversarial/challenge guidance
+
+```bash
+if ! grep -qi "challenge\|adversarial\|rigor\|tier" .squad/agents/critic/charter.md; then
+  echo "FAIL: Critic charter lacks challenge/adversarial language -- may not produce substantive critiques"
+  exit 1
+fi
+echo "OK: Critic charter contains adversarial guidance"
+```
+
+- [ ] Strategies dir exists and is writable
+
+```bash
+STRAT_DIR="$HOME/.ktrdr/shared/strategies"
+mkdir -p "$STRAT_DIR"
+if [ ! -w "$STRAT_DIR" ]; then
+  echo "FAIL: Cannot write to $STRAT_DIR"
+  exit 1
+fi
+echo "OK: Strategies directory writable"
+```
+
+- [ ] CycleState has debate tracking methods
+
+```bash
+python3 -c "
+import sys
+sys.path.insert(0, '.squad')
+from squad_engine.squad_tools import CycleState
+cs = CycleState()
+assert hasattr(cs, 'record_debate'), 'Missing record_debate method'
+assert hasattr(cs, 'record_debate_turn'), 'Missing record_debate_turn method'
+assert hasattr(cs, 'debates'), 'Missing debates field'
+assert hasattr(cs, 'debate_pairs'), 'Missing debate_pairs field'
+print('OK: CycleState has debate tracking (record_debate, record_debate_turn, debates, debate_pairs)')
+"
+```
+
+- [ ] CycleResult has debates field
+
+```bash
+python3 -c "
+import sys
+sys.path.insert(0, '.squad')
+from squad_engine.loop import CycleResult
+cr = CycleResult(iteration=0)
+assert hasattr(cr, 'debates'), 'Missing debates field'
+assert hasattr(cr, 'conversation_log'), 'Missing conversation_log field'
+print('OK: CycleResult has debates and conversation_log fields')
+"
+```
+
+---
+
+## Execution Steps
+
+### Phase 1: Snapshot Pre-Cycle State
+
+Capture baseline state so we can diff strategies and KB after the cycle.
+
+#### 1.1 Record Baseline and Set Cadence to full_squad
+
+**Command:**
+```bash
+SHARED="$HOME/.ktrdr/shared/squad"
+STRAT_DIR="$HOME/.ktrdr/shared/strategies"
+
+# Count existing strategy files
+STRAT_COUNT_BEFORE=$(ls "$STRAT_DIR"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
+echo "Strategies before: $STRAT_COUNT_BEFORE"
+
+# Snapshot all existing strategy names and their checksums
+ls "$STRAT_DIR"/*.yaml 2>/dev/null | while read f; do
+  echo "$(basename "$f"):$(md5 -q "$f" 2>/dev/null || md5sum "$f" | cut -d' ' -f1)"
+done > /tmp/squad-m3-strat-checksums-before.txt
+cat /tmp/squad-m3-strat-checksums-before.txt
+
+# Record experiments.md line count
+EXP_LINES_BEFORE=$(wc -l < "$SHARED/knowledge/experiments.md" | tr -d ' ')
+echo "experiments.md lines before: $EXP_LINES_BEFORE"
+
+# Set cadence to full_squad (required for debate -- quick_iteration skips Critic)
+echo "cadence: full_squad" > "$SHARED/loop/cadence.md"
+echo "Cadence set to full_squad"
+
+# Save baselines
+echo "$STRAT_COUNT_BEFORE" > /tmp/squad-m3-strat-count-before.txt
+echo "$EXP_LINES_BEFORE" > /tmp/squad-m3-exp-lines-before.txt
+
+# Clean prior test output
+rm -f /tmp/squad-m3-cycle-output.txt
+rm -f /tmp/squad-m3-result.json
+```
+
+**Expected:**
+- Baselines captured, cadence set to full_squad
+- Exit code: 0
+
+---
+
+### Phase 2: Run the Cycle
+
+Run one full_squad cycle. The Director should trigger the debate relay pattern:
+Engineer designs, Critic challenges, Director synthesizes and relays, Engineer revises.
+
+#### 2.1 Execute run_cycle
+
+**Command:**
+```bash
+cd /Users/karl/Documents/dev/ktrdr-impl-research-squad-v2-M3
+source .env.sandbox
+
+uv run python3 -c "
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path('.squad')))
+from squad_engine.loop import run_cycle
+
+async def main():
+    result = await run_cycle(
+        iteration=300,
+        shared_dir=str(Path.home() / '.ktrdr/shared/squad'),
+        charter_dir=str(Path('.squad/agents')),
+    )
+
+    # Serialize CycleResult including debate metadata
+    output = {
+        'status': result.status,
+        'iteration': result.iteration,
+        'total_cost_usd': result.total_cost_usd,
+        'agents_spawned': result.agents_spawned,
+        'experiment_result': result.experiment_result,
+        'cadence_next': result.cadence_next,
+        'error': result.error,
+        'duration_seconds': result.duration_seconds,
+        'debates': result.debates,
+        'conversation_log': [
+            {
+                'role': e.role,
+                'message_to_agent': e.message_to_agent,
+                'agent_response': e.agent_response[:500],
+                'cost_usd': e.cost_usd,
+                'turns': e.turns,
+            }
+            for e in result.conversation_log
+        ],
+    }
+    print('CYCLE_RESULT_JSON:' + json.dumps(output, default=str))
+
+asyncio.run(main())
+" 2>&1 | tee /tmp/squad-m3-cycle-output.txt
+```
+
+**Expected:**
+- Output contains `CYCLE_RESULT_JSON:` with valid JSON
+- Duration: 15-45 minutes (debate adds some overhead)
+- agents_spawned should include engineer, critic, and scribe at minimum
+
+#### 2.2 Extract and Save CycleResult JSON
+
+**Command:**
+```bash
+RESULT_LINE=$(grep 'CYCLE_RESULT_JSON:' /tmp/squad-m3-cycle-output.txt | tail -1)
+if [ -z "$RESULT_LINE" ]; then
+  echo "FAIL: No CYCLE_RESULT_JSON found in output"
+  echo "Last 30 lines of output:"
+  tail -30 /tmp/squad-m3-cycle-output.txt
+  exit 1
+fi
+
+RESULT_JSON=$(echo "$RESULT_LINE" | sed 's/^CYCLE_RESULT_JSON://')
+echo "$RESULT_JSON" > /tmp/squad-m3-result.json
+
+# Pretty-print summary
+python3 -c "
+import json
+with open('/tmp/squad-m3-result.json') as f:
+    data = json.load(f)
+print(f'Status: {data[\"status\"]}')
+print(f'Agents: {data[\"agents_spawned\"]}')
+print(f'Cost: \${data[\"total_cost_usd\"]:.4f}')
+print(f'Duration: {data[\"duration_seconds\"]:.1f}s')
+print(f'Debates: {len(data.get(\"debates\", []))}')
+print(f'Conversation entries: {len(data.get(\"conversation_log\", []))}')
+print(f'Error: {data.get(\"error\")}')
+"
+```
+
+**Expected:**
+- JSON parsed successfully
+- Status is COMPLETE, error is None
+
+---
+
+### Phase 3: Validate Debate Mechanics
+
+This is the core M3 validation. We prove multi-turn debate happened with genuine revision.
+
+#### 3.1 Verify Cycle Completed Successfully
+
+**Command:**
+```bash
+python3 -c "
+import json, sys
+
+with open('/tmp/squad-m3-result.json') as f:
+    data = json.load(f)
+
+status = data['status']
+error = data.get('error')
+
+if status != 'COMPLETE':
+    print(f'FAIL: status={status}, error={error}')
+    sys.exit(1)
+
+if error is not None:
+    print(f'FAIL: error is not None: {error}')
+    sys.exit(1)
+
+print('OK: Cycle completed successfully (status=COMPLETE, error=None)')
+"
+```
+
+#### 3.2 Verify Critic Was Spawned (Debate Participant Present)
+
+**Command:**
+```bash
+python3 -c "
+import json, sys
+
+with open('/tmp/squad-m3-result.json') as f:
+    data = json.load(f)
+
+agents = data['agents_spawned']
+print(f'Agents spawned: {agents}')
+
+if 'critic' not in agents:
+    print('FAIL: Critic not spawned -- no debate possible without adversarial agent')
+    print('This means the Director did not trigger the debate relay pattern')
+    sys.exit(1)
+
+if 'engineer' not in agents:
+    print('FAIL: Engineer not spawned -- no strategy to debate')
+    sys.exit(1)
+
+print('OK: Both Engineer and Critic spawned (debate participants present)')
+"
+```
+
+**Expected:**
+- Both `engineer` and `critic` in agents_spawned
+
+#### 3.3 Verify 2+ Turn Exchange Between Engineer and Critic (via Director Relay)
+
+This is the key M3 assertion. The conversation_log must show:
+1. Director -> Engineer (design task)
+2. Director -> Critic (challenge task)
+3. Director -> Engineer again (relay of Critic's concern)
+
+At minimum, Engineer must appear 2+ times in the conversation log.
+
+**Command:**
+```bash
+python3 -c "
+import json, sys
+
+with open('/tmp/squad-m3-result.json') as f:
+    data = json.load(f)
+
+log = data.get('conversation_log', [])
+if not log:
+    print('FAIL: conversation_log is empty -- no exchanges recorded')
+    sys.exit(1)
+
+# Count queries per role
+role_counts = {}
+for entry in log:
+    role = entry['role']
+    role_counts[role] = role_counts.get(role, 0) + 1
+
+print('Query counts per role:')
+for role, count in sorted(role_counts.items()):
+    print(f'  {role}: {count}')
+
+engineer_count = role_counts.get('engineer', 0)
+critic_count = role_counts.get('critic', 0)
+
+if engineer_count < 2:
+    print(f'FAIL: Engineer queried only {engineer_count} time(s) -- need 2+ for debate relay')
+    print('Director must query Engineer at least twice: initial design + revision after Critic')
+    sys.exit(1)
+
+if critic_count < 1:
+    print(f'FAIL: Critic queried 0 times -- no challenge issued')
+    sys.exit(1)
+
+# Verify the debate SEQUENCE: Engineer before Critic before Engineer-again
+roles_in_order = [e['role'] for e in log]
+print(f'Exchange sequence: {\" -> \".join(roles_in_order)}')
+
+# Find pattern: engineer...critic...engineer (with any agents between)
+first_engineer = roles_in_order.index('engineer')
+first_critic = None
+second_engineer = None
+
+for i in range(first_engineer + 1, len(roles_in_order)):
+    if roles_in_order[i] == 'critic' and first_critic is None:
+        first_critic = i
+    elif roles_in_order[i] == 'engineer' and first_critic is not None and second_engineer is None:
+        second_engineer = i
+        break
+
+if first_critic is None:
+    print('FAIL: No Critic query found after initial Engineer query')
+    sys.exit(1)
+
+if second_engineer is None:
+    print('FAIL: No second Engineer query found after Critic -- debate relay did not happen')
+    print('Director received Critic feedback but did not relay it back to Engineer')
+    sys.exit(1)
+
+total_debate_turns = engineer_count + critic_count
+print(f'OK: Debate relay confirmed -- Engineer({engineer_count}) + Critic({critic_count}) = {total_debate_turns} turns')
+print(f'  Exchange {first_engineer+1}: Director -> Engineer (initial design)')
+print(f'  Exchange {first_critic+1}: Director -> Critic (challenge)')
+print(f'  Exchange {second_engineer+1}: Director -> Engineer (revision after Critic relay)')
+"
+```
+
+**Expected:**
+- Engineer queried 2+ times, Critic queried 1+ times
+- Sequence: Engineer -> ... -> Critic -> ... -> Engineer (relay pattern)
+
+#### 3.4 Verify Director Synthesized Critic's Concern (Not Raw Forwarding)
+
+The Director should distill the Critic's output into an actionable concern, not paste it verbatim.
+
+**Command:**
+```bash
+python3 -c "
+import json, sys
+
+with open('/tmp/squad-m3-result.json') as f:
+    data = json.load(f)
+
+log = data.get('conversation_log', [])
+
+# Find the Critic's response and the subsequent Engineer message
+critic_response = None
+relay_message = None
+
+roles_in_order = [e['role'] for e in log]
+first_critic_idx = None
+second_engineer_idx = None
+
+for i, entry in enumerate(log):
+    if entry['role'] == 'critic' and first_critic_idx is None:
+        first_critic_idx = i
+        critic_response = entry['agent_response']
+    elif entry['role'] == 'engineer' and first_critic_idx is not None and second_engineer_idx is None:
+        second_engineer_idx = i
+        relay_message = entry['message_to_agent']
+        break
+
+if critic_response is None or relay_message is None:
+    print('FAIL: Could not find Critic response + subsequent Engineer message for relay analysis')
+    sys.exit(1)
+
+# Synthesis check: the relay message should be SHORTER than the raw Critic response
+# (Director distills, not forwards)
+critic_len = len(critic_response)
+relay_len = len(relay_message)
+
+print(f'Critic response length: {critic_len} chars')
+print(f'Director relay message length: {relay_len} chars')
+
+# Check it is not a raw copy-paste (allow some tolerance for quoting)
+# If relay contains >80% of Critic's response verbatim, that is raw forwarding
+if critic_len > 100:
+    # Find longest common substring as a rough plagiarism check
+    # Simpler heuristic: check if any 200-char chunk of Critic output appears in relay
+    chunk_size = min(200, critic_len // 2)
+    raw_forward = False
+    for start in range(0, critic_len - chunk_size, 50):
+        chunk = critic_response[start:start + chunk_size]
+        if chunk in relay_message:
+            raw_forward = True
+            break
+
+    if raw_forward:
+        print('WARNING: Director appears to have raw-forwarded a large chunk of Critic output')
+        print('Expected synthesis (shorter, actionable) not copy-paste')
+        # This is a WARNING, not FAIL -- the Director may quote briefly
+    else:
+        print('OK: Director relay does not contain large verbatim chunks of Critic output')
+
+# The relay message should reference the concern (some keyword overlap expected)
+# but be shorter or comparable, not longer
+if relay_len > critic_len * 1.5 and relay_len > 300:
+    print(f'WARNING: Relay message ({relay_len}) is longer than Critic response ({critic_len}) -- unusual')
+
+# Print the actual relay message for human review
+print()
+print('=== Director relay message to Engineer (first 500 chars) ===')
+print(relay_message[:500])
+print('=== end ===')
+print()
+print('OK: Director relay message captured for human review')
+"
+```
+
+**Expected:**
+- Relay message is not a verbatim copy of Critic's response
+- Relay message is present and references a concern
+
+#### 3.5 Verify Strategy YAML Is Measurably Different Before and After Revision
+
+The Engineer should produce a revised strategy after receiving the Critic's concern.
+We check that the strategy file was modified (or a second version created).
+
+**Command:**
+```bash
+python3 -c "
+import json, sys
+
+with open('/tmp/squad-m3-result.json') as f:
+    data = json.load(f)
+
+log = data.get('conversation_log', [])
+
+# Find the Engineer's initial response and post-revision response
+engineer_responses = [e for e in log if e['role'] == 'engineer']
+
+if len(engineer_responses) < 2:
+    print(f'FAIL: Only {len(engineer_responses)} Engineer response(s) -- need 2+ for before/after diff')
+    sys.exit(1)
+
+initial = engineer_responses[0]['agent_response']
+revised = engineer_responses[1]['agent_response']
+
+initial_len = len(initial)
+revised_len = len(revised)
+
+print(f'Initial Engineer response: {initial_len} chars')
+print(f'Revised Engineer response: {revised_len} chars')
+
+# They should NOT be identical -- that would mean no revision happened
+if initial == revised:
+    print('FAIL: Initial and revised Engineer responses are IDENTICAL -- no revision occurred')
+    sys.exit(1)
+
+# Compute a rough similarity ratio
+# Using simple set-of-words overlap as proxy
+initial_words = set(initial.lower().split())
+revised_words = set(revised.lower().split())
+
+if initial_words and revised_words:
+    overlap = len(initial_words & revised_words)
+    total = len(initial_words | revised_words)
+    similarity = overlap / total if total > 0 else 0
+    print(f'Word-level similarity: {similarity:.2%}')
+
+    # Some overlap expected (same strategy domain), but not 100%
+    if similarity > 0.95:
+        print('WARNING: Responses are >95% similar -- revision may be superficial')
+    elif similarity < 0.05:
+        print('WARNING: Responses are <5% similar -- may be completely different strategies, not a revision')
+    else:
+        print(f'OK: Responses differ meaningfully (similarity={similarity:.2%})')
+else:
+    print('WARNING: Could not compute similarity (empty responses?)')
+
+print()
+print('OK: Engineer produced different output before and after Critic relay')
+"
+```
+
+**Expected:**
+- Initial and revised Engineer responses are NOT identical
+- Some meaningful difference (not 100% similarity, not 0% similarity)
+
+#### 3.6 Verify Strategy YAML File Changed on Disk
+
+If the Engineer rewrites the strategy file after revision, the on-disk file should differ from the pre-cycle checksum.
+
+**Command:**
+```bash
+STRAT_DIR="$HOME/.ktrdr/shared/strategies"
+STRAT_COUNT_BEFORE=$(cat /tmp/squad-m3-strat-count-before.txt)
+STRAT_COUNT_AFTER=$(ls "$STRAT_DIR"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
+
+echo "Strategy count: before=$STRAT_COUNT_BEFORE, after=$STRAT_COUNT_AFTER"
+
+if [ "$STRAT_COUNT_AFTER" -le "$STRAT_COUNT_BEFORE" ]; then
+  echo "FAIL: No new strategy YAML created (before=$STRAT_COUNT_BEFORE, after=$STRAT_COUNT_AFTER)"
+  exit 1
+fi
+
+# Compare checksums -- find files that are new or changed
+echo ""
+echo "Checksum changes:"
+ls "$STRAT_DIR"/*.yaml 2>/dev/null | while read f; do
+  NAME=$(basename "$f")
+  NEW_HASH=$(md5 -q "$f" 2>/dev/null || md5sum "$f" | cut -d' ' -f1)
+  OLD_HASH=$(grep "^${NAME}:" /tmp/squad-m3-strat-checksums-before.txt 2>/dev/null | cut -d: -f2)
+  if [ -z "$OLD_HASH" ]; then
+    echo "  NEW: $NAME ($NEW_HASH)"
+  elif [ "$OLD_HASH" != "$NEW_HASH" ]; then
+    echo "  CHANGED: $NAME (was $OLD_HASH, now $NEW_HASH)"
+  fi
+done
+
+NEWEST=$(ls -t "$STRAT_DIR"/*.yaml | head -1)
+echo ""
+echo "Newest strategy file: $NEWEST"
+echo "First 10 lines:"
+head -10 "$NEWEST"
+echo ""
+echo "OK: Strategy YAML created or modified on disk"
+```
+
+**Expected:**
+- At least one new or changed strategy file
+- File has valid YAML content
+
+#### 3.7 Verify Debate Metadata in CycleResult
+
+The `debates` field should contain structured metadata about the debate.
+
+**Command:**
+```bash
+python3 -c "
+import json, sys
+
+with open('/tmp/squad-m3-result.json') as f:
+    data = json.load(f)
+
+debates = data.get('debates', [])
+
+if not debates:
+    print('WARNING: debates list is empty -- record_debate() may not have been called')
+    print('This could mean the Director ran the debate but Python did not capture metadata')
+    print('Checking conversation_log as fallback evidence...')
+
+    # Fallback: verify debate happened via conversation_log even if metadata not captured
+    log = data.get('conversation_log', [])
+    engineer_count = sum(1 for e in log if e['role'] == 'engineer')
+    critic_count = sum(1 for e in log if e['role'] == 'critic')
+
+    if engineer_count >= 2 and critic_count >= 1:
+        print(f'  conversation_log shows debate pattern: Engineer={engineer_count}, Critic={critic_count}')
+        print('  Debate occurred but metadata not captured in debates field')
+        print('  This is a partial pass -- metadata recording needs implementation')
+    else:
+        print('FAIL: No debate evidence in either debates field or conversation_log')
+        sys.exit(1)
+else:
+    print(f'Debate metadata entries: {len(debates)}')
+    for i, debate in enumerate(debates):
+        roles = debate.get('roles', [])
+        turns = debate.get('turns', 0)
+        revised = debate.get('revised', False)
+        resolution = debate.get('resolution', '')
+        print(f'  Debate {i+1}: roles={roles}, turns={turns}, revised={revised}')
+        print(f'    Resolution: {resolution[:200]}')
+
+        if turns < 2:
+            print(f'  WARNING: Debate {i+1} has only {turns} turn(s) -- expected 2+')
+
+        if not revised:
+            print(f'  WARNING: Debate {i+1} revised=False -- Engineer did not revise')
+
+    # At least one debate should show revision
+    any_revised = any(d.get('revised', False) for d in debates)
+    if not any_revised:
+        print('WARNING: No debate shows revised=True -- revision may have happened but flag not set')
+
+    print(f'OK: {len(debates)} debate(s) recorded with metadata')
+"
+```
+
+**Expected:**
+- debates list is non-empty (or conversation_log proves debate happened as fallback)
+- At least one debate entry with turns >= 2
+
+#### 3.8 Verify Token Cost Confirms Real Sessions
+
+**Command:**
+```bash
+python3 -c "
+import json, sys
+
+with open('/tmp/squad-m3-result.json') as f:
+    data = json.load(f)
+
+cost = data['total_cost_usd']
+print(f'Total cost: \${cost:.4f}')
+
+if cost <= 0:
+    print('FAIL: total_cost_usd is 0 or negative -- sessions did not run')
+    sys.exit(1)
+
+# With debate, cost should be higher than a minimal cycle
+# Rough expectation: Director + Engineer(2+) + Critic(1+) + Scribe = ~\$2-8
+if cost < 0.50:
+    print(f'WARNING: Cost \${cost:.4f} seems very low for a debate cycle -- possible short-circuit')
+elif cost > 20.0:
+    print(f'WARNING: Cost \${cost:.4f} seems very high -- check for runaway sessions')
+
+print(f'OK: Real Claude sessions confirmed (cost=\${cost:.4f})')
+"
+```
+
+#### 3.9 Verify Conversation Log Shows Director's Synthesis Framing
+
+The relay message from Director to Engineer (after Critic) should contain synthesis
+language -- references to what the Critic found, framed as a question or constraint.
+
+**Command:**
+```bash
+python3 -c "
+import json, sys, re
+
+with open('/tmp/squad-m3-result.json') as f:
+    data = json.load(f)
+
+log = data.get('conversation_log', [])
+
+# Find the relay: first Engineer-message AFTER Critic
+roles = [e['role'] for e in log]
+critic_idx = None
+relay_idx = None
+
+for i, role in enumerate(roles):
+    if role == 'critic' and critic_idx is None:
+        critic_idx = i
+    elif role == 'engineer' and critic_idx is not None and relay_idx is None:
+        relay_idx = i
+        break
+
+if relay_idx is None:
+    print('FAIL: Could not find relay message (Engineer query after Critic)')
+    sys.exit(1)
+
+relay_msg = log[relay_idx]['message_to_agent']
+
+# Look for synthesis indicators: reference to concern, question framing, constraint language
+synthesis_indicators = [
+    r'concern',
+    r'raises?\b',
+    r'identif',
+    r'point(s|ed)? out',
+    r'challeng',
+    r'overfit',
+    r'address',
+    r'revis',
+    r'adjust',
+    r'your response',
+    r'how (would|will|do) you',
+    r'critic',
+    r'featur',
+    r'risk',
+    r'suggest',
+]
+
+found = []
+for pattern in synthesis_indicators:
+    if re.search(pattern, relay_msg, re.IGNORECASE):
+        found.append(pattern)
+
+print(f'Synthesis indicators found in relay message: {len(found)}/{len(synthesis_indicators)}')
+for f_pattern in found:
+    print(f'  matched: {f_pattern}')
+
+if len(found) == 0:
+    print('WARNING: No synthesis indicators found -- Director may not be synthesizing Critic output')
+    print('Relay message (first 300 chars):')
+    print(relay_msg[:300])
+else:
+    print(f'OK: Director relay shows synthesis language ({len(found)} indicators)')
+"
+```
+
+**Expected:**
+- At least 1-2 synthesis indicators in the relay message
+
+---
+
+### Phase 4: Verify Side Effects
+
+#### 4.1 Verify experiments.md Was Modified (Scribe Recorded)
+
+**Command:**
+```bash
+SHARED="$HOME/.ktrdr/shared/squad"
+EXP_LINES_BEFORE=$(cat /tmp/squad-m3-exp-lines-before.txt)
+EXP_LINES_AFTER=$(wc -l < "$SHARED/knowledge/experiments.md" | tr -d ' ')
+
+echo "experiments.md: before=$EXP_LINES_BEFORE, after=$EXP_LINES_AFTER"
+
+if [ "$EXP_LINES_AFTER" -le "$EXP_LINES_BEFORE" ]; then
+  echo "FAIL: experiments.md not modified after cycle"
+  exit 1
+fi
+
+GROWTH=$(( EXP_LINES_AFTER - EXP_LINES_BEFORE ))
+echo "Growth: $GROWTH lines"
+echo "OK: experiments.md grew by $GROWTH lines"
+```
+
+#### 4.2 Verify Conversation Log Written to Disk
+
+**Command:**
+```bash
+LOG_FILE="$HOME/.ktrdr/shared/squad/logs/cycle_300_conversation.md"
+if [ ! -f "$LOG_FILE" ]; then
+  echo "FAIL: Conversation log not written to $LOG_FILE"
+  exit 1
+fi
+
+LINE_COUNT=$(wc -l < "$LOG_FILE" | tr -d ' ')
+echo "Conversation log: $LOG_FILE ($LINE_COUNT lines)"
+
+# Check log mentions both Critic and Engineer
+if grep -qi "critic" "$LOG_FILE" && grep -qi "engineer" "$LOG_FILE"; then
+  echo "OK: Conversation log references both Critic and Engineer"
+else
+  echo "WARNING: Conversation log may not contain both debate participants"
+fi
+
+# Show a snippet for review
+echo ""
+echo "=== First 30 lines ==="
+head -30 "$LOG_FILE"
+echo "=== end ==="
+```
+
+---
+
+## Success Criteria
+
+All must pass:
+
+- [ ] Cycle completes with status=COMPLETE and error=None
+- [ ] Both Engineer and Critic spawned (debate participants present)
+- [ ] Engineer queried 2+ times (initial design + post-relay revision)
+- [ ] Critic queried 1+ times (challenge issued)
+- [ ] Debate sequence confirmed: Engineer -> ... -> Critic -> ... -> Engineer
+- [ ] Engineer's pre-revision and post-revision responses are measurably different
+- [ ] Director's relay message is not a raw copy-paste of Critic's output
+- [ ] total_cost_usd > 0 (real Claude sessions ran)
+- [ ] New or modified strategy YAML on disk
+- [ ] experiments.md grew (Scribe recorded results)
+
+---
+
+## Sanity Checks
+
+**CRITICAL:** These catch false positives
+
+| Check | What It Catches |
+|-------|----------------|
+| Engineer queried 2+ times in conversation_log | Director received Critic feedback but never relayed it (skipped revision) |
+| Debate sequence (E -> C -> E) not just counts | Director queried Engineer twice for unrelated reasons, Critic queried but not as part of debate |
+| Engineer responses differ (word-level similarity check) | Engineer returned the same strategy both times (rubber-stamp revision) |
+| Relay message not verbatim Critic output | Director copy-pasted Critic's raw response instead of synthesizing |
+| Relay message has synthesis indicators | Director sent a generic "please revise" without referencing Critic's specific concern |
+| total_cost_usd > 0 | Mocked or short-circuited sessions |
+| Strategy YAML checksum changed on disk | Strategy file exists from before the cycle, not actually modified |
+| Critic charter checked in preflight | Critic without adversarial guidance produces soft reviews that trigger no revision |
+| debates metadata checked (with fallback) | Python captured the debate but record_debate() not called -- still valid if conversation_log proves it |
+
+---
+
+## Failure Categorization
+
+| Failure | Category | Action |
+|---------|----------|--------|
+| CYCLE_RESULT_JSON not found | EXECUTION_FAILURE | Check /tmp/squad-m3-cycle-output.txt for Python traceback |
+| status=FAILED | ORCHESTRATION_FAILURE | Read error field -- Director may have failed tool calls |
+| Critic not in agents_spawned | DIRECTOR_INTELLIGENCE | Director skipped Critic in full_squad mode -- strengthen DESIGN_CHALLENGE section in director_prompt.py |
+| Engineer queried only once | DIRECTOR_RELAY_FAILURE | Director received Critic output but did not relay to Engineer -- check DEBATE_RELAY prompt section |
+| No debate sequence (E->C->E) | DIRECTOR_RELAY_FAILURE | Director queried agents in wrong order or skipped relay step |
+| Engineer responses identical | ENGINEER_FAILURE | Engineer ignored the Critic concern -- check if relay message was actionable |
+| Relay is raw copy-paste | DIRECTOR_SYNTHESIS_FAILURE | Director not following "Synthesize, Don't Forward" guidance -- strengthen RELAY_PATTERN instructions |
+| No synthesis indicators | DIRECTOR_SYNTHESIS_FAILURE | Relay message is generic ("please revise") without Critic's specific concern |
+| debates list empty | METADATA_FAILURE | record_debate() not called by Python -- check spawn_agent_tool or cycle flow |
+| total_cost_usd == 0 | SESSION_FAILURE | Claude sessions did not connect -- check claude CLI |
+| experiments.md not modified | SCRIBE_FAILURE | Scribe was not spawned or failed silently |
+| Strategy YAML not created | ENGINEER_FAILURE | Engineer did not write YAML or wrong path |
+
+---
+
+## Troubleshooting
+
+**If Critic is not spawned:**
+- full_squad cadence should trigger Critic via DESIGN_CHALLENGE instructions
+- Check director_prompt.py includes DESIGN_CHALLENGE section
+- Check cadence.md was actually set to full_squad: `cat ~/.ktrdr/shared/squad/loop/cadence.md`
+- The Director has discretion -- it may skip Critic if KB state suggests iteration over challenge
+- If consistently skipped, strengthen the DESIGN_CHALLENGE instructions to make Critic mandatory in full_squad
+
+**If Engineer is only queried once (no relay):**
+- The Director received Critic feedback but decided not to relay it
+- Check the Critic's response in conversation_log -- was it substantive enough to warrant relay?
+- Check DEBATE_RELAY section instructs the Director to always relay back
+- The Director may have judged Critic's concerns as minor and proceeded without revision
+- If consistently happening, add explicit instruction: "ALWAYS relay Critic concerns to Engineer for response"
+
+**If Engineer responses are identical:**
+- The relay message may not have been actionable
+- Check what the Director told Engineer in the relay -- was it specific?
+- Engineer may have refused to revise (argued the design is fine)
+- Check if the strategy YAML on disk changed even if the response text is similar
+
+**If Director raw-forwards Critic output:**
+- The RELAY_PATTERN section says "Synthesize, Don't Forward" but is advisory
+- Strengthen the instruction or add an example of good vs bad relay
+- Check if the relay message length exceeds Critic response length (bloated relay)
+
+**If debates metadata is empty but conversation_log shows debate:**
+- The record_debate() call may not be wired into the tool flow yet
+- This is a partial pass -- the debate happened but Python did not capture structured metadata
+- Check if CycleState.record_debate() is called after the debate resolves
+- The spawn_agent_tool may need to detect debate patterns and call record_debate_turn()
+
+**If the cycle hangs:**
+- Training + backtest execution dominates (10-30 min normal)
+- Debate adds 5-10 min of additional LLM queries
+- Check executor.sh 15-minute stall timeout
+- Check sandbox health: `curl http://localhost:${KTRDR_API_PORT}/api/v1/health`
+- Check for stuck claude processes: `ps aux | grep claude`
+
+---
+
+## Evidence to Capture
+
+- Full /tmp/squad-m3-cycle-output.txt (all session logs)
+- /tmp/squad-m3-result.json (parsed CycleResult with debates + conversation_log)
+- Conversation log on disk: ~/.ktrdr/shared/squad/logs/cycle_300_conversation.md
+- Strategy YAML file(s) created or modified (path + first 20 lines)
+- Director relay message to Engineer (full text from conversation_log)
+- Critic response (full text from conversation_log)
+- Engineer initial vs revised response comparison
+- experiments.md diff (before/after line count + tail of new content)
+- debates metadata from CycleResult
+- Total cost and duration

--- a/.squad/squad_engine/agent_manager.py
+++ b/.squad/squad_engine/agent_manager.py
@@ -37,10 +37,16 @@ class AgentManager:
         self._charter_dir = charter_dir or Path(__file__).resolve().parent.parent / "agents"
         self._allowed_roles = allowed_roles or ALL_ROLES
         self._sessions: dict[str, PersistentAgentSession] = {}
+        self._query_counts: dict[str, int] = {}
 
     @property
     def active_sessions(self) -> dict[str, PersistentAgentSession]:
         return dict(self._sessions)
+
+    @property
+    def query_counts(self) -> dict[str, int]:
+        """Query count per role in this cycle. Used for debate depth control."""
+        return dict(self._query_counts)
 
     @property
     def total_cost_usd(self) -> float:
@@ -76,6 +82,8 @@ class AgentManager:
             await session.start(context_files=context_paths)
             logger.info("Spawned new session for %s", role)
 
+        self._query_counts[role] = self._query_counts.get(role, 0) + 1
+
         session = self._sessions[role]
         return await session.query(message)
 
@@ -88,6 +96,7 @@ class AgentManager:
                 logger.exception("Error tearing down %s session", role)
 
         self._sessions.clear()
+        self._query_counts.clear()
         logger.info("All sessions torn down")
 
     def _create_session(self, role: str) -> PersistentAgentSession:

--- a/.squad/squad_engine/director_prompt.py
+++ b/.squad/squad_engine/director_prompt.py
@@ -101,6 +101,77 @@ When relaying consultant output to the Engineer, synthesize the key insight.
 Extract the actionable insight. Drop the reasoning chain. The Engineer needs the conclusion and constraint, not the consultant's internal deliberation.
 """
 
+DEBATE_RELAY = """
+## Debate Relay Pattern
+
+When a consultant raises a substantive concern, don't just acknowledge it — relay
+it to the Engineer for genuine revision. Multi-turn debate produces better strategies.
+
+**The relay flow:**
+1. Spawn Engineer with a design task
+2. Spawn Critic (or other consultant): "Challenge this design: [your synthesis]"
+3. Relay Critic's concerns to Engineer: "Critic raises two concerns: (1) ... (2) ... Address both."
+4. Engineer revises (or argues back with evidence)
+5. You decide: relay revision back to Critic, or accept and proceed
+
+**Key: You synthesize — you don't copy-paste.**
+
+- **Bad relay:** "Here's what Critic said: [raw 500-word response]"
+- **Good relay:** "Critic's core concern: your 12-feature input vector likely overfits on 6 months of 5m data. Suggested constraint: ≤6 features. Your response?"
+
+Extract the actionable concern. Drop the reasoning chain. Frame it as something
+the Engineer must address — a question or constraint, not a lecture.
+
+Each debate turn costs ~5-10K tokens. Budget accordingly.
+
+### When to Continue a Debate
+- The agent raised a factual concern that hasn't been addressed yet
+- The revision is substantive and merits re-evaluation
+- Concrete evidence was requested but not yet provided
+
+### When to Resolve a Debate
+- Agents are repeating themselves (no new arguments)
+- The disagreement is preference-based, not factual
+- 4+ turns without convergence — diminishing returns
+- Remaining concerns are minor and acknowledged
+
+**Maximum: 5 turns per debate pair.** Python enforces this — after 5 turns between
+the same two agents, spawn_agent returns a limit message. Resolve and proceed.
+"""
+
+DESIGN_CHALLENGE = """
+## Pre-Execution Design Challenge (MANDATORY in full_squad)
+
+**REQUIRED STEP: In full_squad cadence, you MUST challenge the Engineer's strategy
+design BEFORE calling execute_experiment.** Do not skip this. Even if the cycle feels
+urgent or the KB state pressures you to execute quickly — the design challenge catches
+costly mistakes before they waste training compute.
+
+**The exact sequence you must follow:**
+1. Spawn Engineer with the design task → Engineer produces strategy YAML
+2. Spawn Critic with the Engineer's design: "Challenge this strategy for: overfitting
+   risk, feature validity, labeling bias, lookahead contamination, out-of-sample design.
+   Use your Tier framework."
+3. Read the Critic's response. Synthesize the top 1-2 concerns into an actionable message.
+4. Spawn Engineer again: "Critic raises these concerns: [your synthesis]. Address them
+   by revising the strategy or arguing with evidence why they don't apply."
+5. Engineer revises the strategy (or argues back with evidence)
+6. Decide: accept the revision and proceed to execute_experiment, or send back to Critic
+
+**This is the debate relay pattern.** Steps 2-5 are the minimum — one Critic challenge
+and one Engineer response. You may do additional rounds if the concern is unresolved.
+
+**IMPORTANT: Do not skip the relay.** After receiving the Critic's response from
+spawn_agent, you MUST call spawn_agent(engineer, ...) with a synthesized version
+of the Critic's top concern. Do NOT apply the Critic's framework yourself — the
+value is in the Engineer seeing the challenge and responding with a revision.
+Even if the Critic finds no blocking issues, relay the top concern to the Engineer
+for response before proceeding to execute_experiment.
+
+**Skip ONLY for quick_iteration** where the design is a minor variant of an
+already-challenged strategy.
+"""
+
 KB_FILE_MAP = """
 ## Knowledge Base
 
@@ -149,6 +220,10 @@ def build_director_prompt(
         CONTEXT_ROUTING,
         "",
         CONSULTANT_TRIGGERS,
+        "",
+        DEBATE_RELAY,
+        "",
+        DESIGN_CHALLENGE,
         "",
         KB_FILE_MAP,
         "",
@@ -217,8 +292,9 @@ def _build_task_instructions(cadence: str) -> list[str]:
             "1. **ORIENT**: Read the knowledge base (synthesis.md, frontiers.md, nudges).",
             "   Understand where the research is and decide this cycle's mission.",
             "2. **WORK**: Decide which consultants to bring in based on the situation.",
-            "   Spawn the Engineer with a mission. Consult Quant, Inventor, Scout,",
-            "   Critic, or Architect as needed — see 'When to Consult' above.",
+            "   Spawn the Engineer with a design mission. **Then follow the mandatory",
+            "   Pre-Execution Design Challenge: send the design to Critic, relay the",
+            "   Critic's top concern back to Engineer, and have Engineer revise.**",
             "   Use validate_strategy to check YAML. Use execute_experiment to run",
             "   training + backtest. Send results to the Engineer for evaluation.",
             "3. **LEARN**: Spawn Scribe to record what happened.",

--- a/.squad/squad_engine/loop.py
+++ b/.squad/squad_engine/loop.py
@@ -43,6 +43,7 @@ class CycleResult:
     duration_seconds: float = 0.0
     conversation_log: list[ConversationEntry] = field(default_factory=list)
     director_transcript: list[dict] = field(default_factory=list)
+    debates: list[dict] = field(default_factory=list)
 
 
 async def run_cycle(
@@ -271,6 +272,7 @@ async def _run_director_session(
         result.cadence_next = cycle_state.cadence_next
         result.conversation_log = cycle_state.conversation_log
         result.director_transcript = director_result.transcript
+        result.debates = cycle_state.debates
 
         if cycle_state.cycle_complete:
             result.status = "COMPLETE"

--- a/.squad/squad_engine/squad_tools.py
+++ b/.squad/squad_engine/squad_tools.py
@@ -29,6 +29,9 @@ class ConversationEntry:
     turns: int = 0
 
 
+MAX_DEBATE_TURNS = 5
+
+
 @dataclass
 class CycleState:
     """Mutable state shared across tool calls within a single cycle.
@@ -42,6 +45,38 @@ class CycleState:
     cadence_next: str = "full_squad"
     cycle_complete: bool = False
     conversation_log: list[ConversationEntry] = field(default_factory=list)
+    debate_pairs: dict[tuple[str, str], int] = field(default_factory=dict)
+    debates: list[dict] = field(default_factory=list)
+    last_spawned_role: str | None = None
+
+    def _pair_key(self, role_a: str, role_b: str) -> tuple[str, str]:
+        """Sorted pair key so (A,B) == (B,A)."""
+        return tuple(sorted([role_a, role_b]))
+
+    def record_debate_turn(self, role_a: str, role_b: str) -> None:
+        """Record one turn in a debate between two roles."""
+        key = self._pair_key(role_a, role_b)
+        self.debate_pairs[key] = self.debate_pairs.get(key, 0) + 1
+
+    def is_debate_limit_reached(self, role_a: str, role_b: str) -> bool:
+        """Check if this debate pair has hit the 5-turn maximum."""
+        key = self._pair_key(role_a, role_b)
+        return self.debate_pairs.get(key, 0) >= MAX_DEBATE_TURNS
+
+    def record_debate(
+        self,
+        roles: list[str],
+        turns: int,
+        revised: bool,
+        resolution: str,
+    ) -> None:
+        """Record structured metadata for a completed debate."""
+        self.debates.append({
+            "roles": roles,
+            "turns": turns,
+            "revised": revised,
+            "resolution": resolution,
+        })
 
 
 def create_squad_mcp_server(
@@ -102,6 +137,28 @@ def create_squad_mcp_server(
         context = input.get("context")
 
         logger.info("Director spawning %s: %s", role, message[:100])
+
+        # Track debate turns between consecutive different roles
+        prev = cycle_state.last_spawned_role
+        if prev and prev != role:
+            # Check limit before spawning
+            if cycle_state.is_debate_limit_reached(prev, role):
+                logger.info(
+                    "Debate limit reached for %s ↔ %s (5 turns). Returning limit message.",
+                    prev, role,
+                )
+                cycle_state.last_spawned_role = role
+                return {
+                    "output": (
+                        f"Debate between {prev} and {role} reached the 5-turn limit. "
+                        "Please resolve the discussion and proceed."
+                    ),
+                    "cost_usd": 0.0,
+                    "turns": 0,
+                }
+            cycle_state.record_debate_turn(prev, role)
+
+        cycle_state.last_spawned_role = role
 
         result = await agent_manager.spawn_agent(role, message, context)
 

--- a/docs/designs/research-squad-v2/implementation/HANDOFF_M3.md
+++ b/docs/designs/research-squad-v2/implementation/HANDOFF_M3.md
@@ -1,0 +1,92 @@
+# Handoff — M3: Multi-Turn Debate
+
+## Status: COMPLETE — Tasks 3.1-3.4 done
+
+## Task 3.1: Multi-Turn Relay Mechanism
+
+### What Was Built
+- Added `_query_counts` dict to AgentManager — tracks queries per role per cycle
+- Added `query_counts` property (returns copy) for external access
+- `teardown_all()` resets query counts alongside sessions
+- Added `DEBATE_RELAY` section to `director_prompt.py` with:
+  - Numbered relay flow (spawn Engineer → Critic → relay → revise → decide)
+  - Good/bad relay examples specific to debate synthesis
+  - Token budget guidance (~5-10K tokens per debate turn)
+
+### Tests Added (10 new, 77 total)
+- `TestM3QueryCountTracking`: 5 tests (init empty, first=1, increment, per-role, teardown resets)
+- `TestM3DebateRelayPattern`: 5 tests (dedicated section, flow, bad example, good example, token budget)
+
+### Gotchas
+1. M2 already had a "Relay Pattern — Synthesize, Don't Forward" section in CONSULTANT_TRIGGERS. M3's DEBATE_RELAY is a separate, more detailed section specifically about multi-turn back-and-forth. Both coexist.
+2. Query counts track per-role, not per-pair. Pair tracking comes in Task 3.2 for debate depth control.
+
+## Task 3.2: Debate Depth Control
+
+### What Was Built
+- Added debate resolution heuristics to `DEBATE_RELAY` section in `director_prompt.py`:
+  - "When to Continue" (factual concerns unaddressed, evidence pending)
+  - "When to Resolve" (repeating, preference-based, 4+ turns)
+  - 5-turn maximum with note about Python enforcement
+- Added to `CycleState` in `squad_tools.py`:
+  - `debate_pairs` dict with sorted tuple keys for pair tracking
+  - `record_debate_turn()` and `is_debate_limit_reached()` methods
+  - `debates` list with `record_debate()` for structured metadata
+  - `MAX_DEBATE_TURNS = 5` constant
+- Added `debates` field to `CycleResult` in `loop.py` — wired from CycleState
+
+### Tests Added (16 new, 92 total)
+- `TestM3DebateDepthHeuristics`: 4 tests (continue heuristics, resolve heuristics, turn limit, token budget)
+- `TestM3DebateTurnPairTracking`: 8 tests (init, track, increment, sorted key, independent pairs, under limit, at limit, untracked)
+- `TestM3DebateMetadata`: 3 tests (init empty, record metadata, multiple debates)
+
+### Gotchas
+1. Pair keys are sorted tuples — `("critic", "engineer")` not `("engineer", "critic")`. This ensures A↔B and B↔A are the same debate.
+2. The safety valve is data-only (CycleState methods). The spawn_agent tool handler in squad_tools.py doesn't enforce it yet — the Director's prompt guides it, and it's available for tool-level enforcement if needed. The M3 plan says "spawn_agent returns a message" but this is deferred to when we need tool-level enforcement since the Director prompt + query count already provides the mechanism.
+
+## Task 3.3: Engineer ↔ Critic Design Challenge Pattern
+
+### What Was Built
+- Added `DESIGN_CHALLENGE` section to `director_prompt.py` with:
+  - Pre-execution challenge workflow (6 numbered steps)
+  - Reference to Critic's Tier 1/2/3 framework
+  - Key concerns: overfitting, lookahead contamination, data leakage
+  - Cadence-aware: default for full_squad, skip for quick_iteration
+- Prompt now ~2250 tokens — well within budget
+
+### Tests Added (6 new, 98 total)
+- `TestM3DesignChallenge`: 6 tests (dedicated section, critic tiers, key concerns, pre-execution, full_squad default, quick_iteration skip)
+
+### Prompt Iterations (from E2E validation)
+The DESIGN_CHALLENGE section went through 3 iterations based on E2E testing:
+1. **v1 (advisory):** "Before calling execute_experiment, have the Critic review..." — Director ignored it (run 1, iter=300)
+2. **v2 (mandatory):** "You MUST challenge" + numbered steps — Director called Critic but self-applied framework instead of relaying (run 2, iter=301)
+3. **v3 (anti-bypass):** Added "Do NOT apply the Critic's framework yourself" + "MUST call spawn_agent(engineer, ...) after Critic" — Director followed the full E→C→E relay (run 3, iter=302)
+
+Key learning: LLM Directors need explicit anti-bypass language, not just mandatory language. The Director will find shortcuts (self-assessment) unless the prompt specifically prohibits them.
+
+## Task 3.4: E2E Validation
+
+### Results
+- **E2E test recipe:** `.claude/skills/ke2e/tests/squad/m3-debate-genuine-revision.md`
+- **Run 1 (iter=300):** FAILED — DIRECTOR_RELAY_FAILURE. Critic used for retrospective analysis, never challenged new design.
+- **Run 2 (iter=301):** FAILED — DIRECTOR_RELAY_FAILURE. Director called Critic 3x but said "MCP agents not returning text" and self-applied framework. Never relayed to Engineer.
+- **Run 3 (iter=302):** PASSED — Full E→C→E relay confirmed. Director synthesized Critic's top 2 concerns and relayed to Engineer.
+
+### Evidence (Run 3)
+- Cost: $10.16, Duration: 180 min
+- All 7 agents spawned (engineer x5, critic x4, plus scribe, quant, inventor, scout, architect)
+- Debate sequence confirmed: Engineer (design) → Critic (challenge) → Engineer (relay + revision)
+- Director synthesized: "Two design concerns on C401 to address before we execute: 1. Temporal frequency mismatch... 2. Failure mode disambiguation..."
+- Strategy YAML created: squad_c401_yield_spread_1h.yaml, squad_c401_cross_pair_1h.yaml
+- experiments.md grew by 90 lines
+
+### Post-Validation: Wired Python Debate Enforcement
+- `spawn_agent_tool` now tracks `last_spawned_role` on CycleState
+- Consecutive different-role spawns auto-call `record_debate_turn()`
+- Before spawning, checks `is_debate_limit_reached()` — returns limit message (no agent call) if 5-turn max hit
+- Same-role consecutive spawns don't create debate turns
+- 5 new tests in `TestM3SpawnAgentDebateEnforcement` (103 total)
+
+### Remaining Gap
+`record_debate()` (structured metadata: roles, turns, revised, resolution) is still not auto-called. Detecting "revised" and "resolution" requires semantic understanding — could be addressed with a dedicated `resolve_debate` tool the Director calls explicitly.

--- a/tests/unit/squad/test_agent_manager.py
+++ b/tests/unit/squad/test_agent_manager.py
@@ -361,3 +361,132 @@ class TestM2AllRolesAvailable:
         mock_quant.stop.assert_awaited_once()
         mock_critic.stop.assert_awaited_once()
         assert len(manager.active_sessions) == 0
+
+
+# ---------------------------------------------------------------------------
+# M3: Multi-Turn Relay — Query Count Tracking
+# ---------------------------------------------------------------------------
+
+
+class TestM3QueryCountTracking:
+    """AgentManager tracks query count per role per cycle for debate depth control."""
+
+    @pytest.fixture
+    def full_kb_dir(self, tmp_path: Path) -> Path:
+        """Create KB + charter structure for all roles."""
+        squad_dir = tmp_path / "squad"
+        shared_dir = tmp_path / "shared"
+        for role in (
+            "engineer",
+            "critic",
+            "inventor",
+            "quant",
+            "scout",
+            "architect",
+            "scribe",
+        ):
+            agent_dir = squad_dir / "agents" / role
+            agent_dir.mkdir(parents=True)
+            (agent_dir / "charter.md").write_text(f"You are the {role}.")
+            history_dir = shared_dir / "agents" / role
+            history_dir.mkdir(parents=True)
+            (history_dir / "history.md").write_text(f"## {role} history")
+        return tmp_path
+
+    @pytest.fixture
+    def full_context_loader(self, full_kb_dir: Path) -> ContextLoader:
+        return ContextLoader(shared_dir=str(full_kb_dir / "shared"))
+
+    @pytest.mark.asyncio
+    async def test_query_counts_initialized_empty(
+        self, full_kb_dir, full_context_loader
+    ):
+        """Fresh AgentManager has empty query counts."""
+        manager = AgentManager(
+            context_loader=full_context_loader,
+            charter_dir=full_kb_dir / "squad" / "agents",
+        )
+        assert manager.query_counts == {}
+
+    @pytest.mark.asyncio
+    async def test_first_spawn_sets_count_to_one(
+        self, full_kb_dir, full_context_loader
+    ):
+        """First spawn_agent call for a role sets count to 1."""
+        manager = AgentManager(
+            context_loader=full_context_loader,
+            charter_dir=full_kb_dir / "squad" / "agents",
+        )
+        mock_session = _make_mock_session()
+
+        with patch(
+            "squad_engine.agent_manager.PersistentAgentSession",
+            return_value=mock_session,
+        ):
+            await manager.spawn_agent("engineer", "Design strategy")
+
+        assert manager.query_counts["engineer"] == 1
+
+    @pytest.mark.asyncio
+    async def test_subsequent_spawns_increment_count(
+        self, full_kb_dir, full_context_loader
+    ):
+        """Multiple spawn_agent calls for same role increment count."""
+        manager = AgentManager(
+            context_loader=full_context_loader,
+            charter_dir=full_kb_dir / "squad" / "agents",
+        )
+        mock_session = _make_mock_session()
+
+        with patch(
+            "squad_engine.agent_manager.PersistentAgentSession",
+            return_value=mock_session,
+        ):
+            await manager.spawn_agent("engineer", "First message")
+            await manager.spawn_agent("engineer", "Second message")
+            await manager.spawn_agent("engineer", "Third message")
+
+        assert manager.query_counts["engineer"] == 3
+
+    @pytest.mark.asyncio
+    async def test_different_roles_tracked_independently(
+        self, full_kb_dir, full_context_loader
+    ):
+        """Query counts are per-role, not global."""
+        manager = AgentManager(
+            context_loader=full_context_loader,
+            charter_dir=full_kb_dir / "squad" / "agents",
+        )
+        mock_eng = _make_mock_session()
+        mock_critic = _make_mock_session()
+        sessions = {"engineer": mock_eng, "critic": mock_critic}
+
+        with patch(
+            "squad_engine.agent_manager.PersistentAgentSession",
+            side_effect=lambda **kw: sessions[kw["role"]],
+        ):
+            await manager.spawn_agent("engineer", "Msg 1")
+            await manager.spawn_agent("engineer", "Msg 2")
+            await manager.spawn_agent("critic", "Challenge")
+
+        assert manager.query_counts["engineer"] == 2
+        assert manager.query_counts["critic"] == 1
+
+    @pytest.mark.asyncio
+    async def test_teardown_resets_query_counts(self, full_kb_dir, full_context_loader):
+        """teardown_all resets query counts for next cycle."""
+        manager = AgentManager(
+            context_loader=full_context_loader,
+            charter_dir=full_kb_dir / "squad" / "agents",
+        )
+        mock_session = _make_mock_session()
+
+        with patch(
+            "squad_engine.agent_manager.PersistentAgentSession",
+            return_value=mock_session,
+        ):
+            await manager.spawn_agent("engineer", "Work")
+            assert manager.query_counts["engineer"] == 1
+
+            await manager.teardown_all()
+            assert manager.query_counts == {}

--- a/tests/unit/squad/test_cycle.py
+++ b/tests/unit/squad/test_cycle.py
@@ -391,11 +391,25 @@ class TestM2ConversationLog:
             ],
             director_transcript=[
                 {"role": "assistant", "type": "text", "content": "Reading KB state..."},
-                {"role": "assistant", "type": "tool_use", "tool": "spawn_agent",
-                 "input": {"role": "engineer", "message": "Design a GRU strategy"}, "id": "t1"},
-                {"role": "assistant", "type": "text", "content": "Engineer produced a design. Checking costs."},
-                {"role": "assistant", "type": "tool_use", "tool": "spawn_agent",
-                 "input": {"role": "quant", "message": "Check costs"}, "id": "t2"},
+                {
+                    "role": "assistant",
+                    "type": "tool_use",
+                    "tool": "spawn_agent",
+                    "input": {"role": "engineer", "message": "Design a GRU strategy"},
+                    "id": "t1",
+                },
+                {
+                    "role": "assistant",
+                    "type": "text",
+                    "content": "Engineer produced a design. Checking costs.",
+                },
+                {
+                    "role": "assistant",
+                    "type": "tool_use",
+                    "tool": "spawn_agent",
+                    "input": {"role": "quant", "message": "Check costs"},
+                    "id": "t2",
+                },
             ],
         )
 
@@ -432,13 +446,185 @@ class TestM2ConversationLog:
         assert "Challenge this RSI strategy design" in content
         assert "RSI period is too short" in content
 
+
+# ---------------------------------------------------------------------------
+# M3: Multi-Turn Debate Relay Pattern
+# ---------------------------------------------------------------------------
+
+
+class TestM3DebateRelayPattern:
+    """Director prompt includes debate relay pattern with good/bad examples."""
+
+    def _build_prompt(self, tmp_path, cadence="full_squad"):
+        charter = tmp_path / "charter.md"
+        charter.write_text("You are the Director.")
+        return build_director_prompt(
+            charter_path=charter,
+            iteration=1,
+            cadence=cadence,
+            nudges="",
+        )
+
+    def test_prompt_has_dedicated_debate_section(self, tmp_path: Path):
+        """Director prompt must have a section specifically about debate relay."""
+        prompt = self._build_prompt(tmp_path)
+        # Must have a debate-specific section header, not just M2's "Relay Pattern"
+        assert "Debate" in prompt, "Prompt should have a section about debate relay"
+
+    def test_prompt_describes_multi_turn_relay_flow(self, tmp_path: Path):
+        """Prompt describes the numbered debate flow: spawn Engineer, spawn Critic, relay back."""
+        prompt = self._build_prompt(tmp_path)
+        prompt_lower = prompt.lower()
+        # Should describe the back-and-forth pattern explicitly
+        assert "spawn" in prompt_lower
+        # Must mention relaying Critic's concerns back to Engineer
+        assert "concern" in prompt_lower or "challenge" in prompt_lower
+
+    def test_prompt_shows_debate_bad_relay_example(self, tmp_path: Path):
+        """Prompt shows a bad debate relay example (raw-forwarding a long response)."""
+        prompt = self._build_prompt(tmp_path)
+        # Should have a specific bad example for debate (not just M2's consultation relay)
+        # The debate bad example mentions raw forwarding of a long response
+        assert "500-word" in prompt or "raw" in prompt.lower()
+
+    def test_prompt_shows_debate_good_relay_example(self, tmp_path: Path):
+        """Prompt shows a good debate relay example (distilling the core concern)."""
+        prompt = self._build_prompt(tmp_path)
+        prompt_lower = prompt.lower()
+        # Good relay: Director extracts core concern and frames it as a question
+        assert "core concern" in prompt_lower or "overfit" in prompt_lower
+
+    def test_prompt_within_token_budget_with_debate(self, tmp_path: Path):
+        """Prompt with debate additions should still stay within token budget."""
+        prompt = self._build_prompt(tmp_path)
+        estimated_tokens = len(prompt) // 4
+        # Budget expanded slightly for debate content — but stay reasonable
+        assert estimated_tokens < 5000, f"Prompt too large: ~{estimated_tokens} tokens"
+
+
+# ---------------------------------------------------------------------------
+# M3: Debate Depth Control — Director Prompt Heuristics
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# M3: Engineer ↔ Critic Design Challenge Pattern
+# ---------------------------------------------------------------------------
+
+
+class TestM3DesignChallenge:
+    """Director prompt includes pre-execution design challenge workflow."""
+
+    def _build_prompt(self, tmp_path, cadence="full_squad"):
+        charter = tmp_path / "charter.md"
+        charter.write_text("You are the Director.")
+        return build_director_prompt(
+            charter_path=charter,
+            iteration=1,
+            cadence=cadence,
+            nudges="",
+        )
+
+    def test_prompt_has_design_challenge_section(self, tmp_path: Path):
+        """Prompt must have a dedicated design challenge section."""
+        prompt = self._build_prompt(tmp_path)
+        assert "Design Challenge" in prompt or "design challenge" in prompt.lower()
+
+    def test_prompt_challenge_references_critic_tiers(self, tmp_path: Path):
+        """Challenge workflow should reference Critic's Tier 1/2/3 framework."""
+        prompt = self._build_prompt(tmp_path)
+        assert "Tier" in prompt or "tier" in prompt.lower()
+
+    def test_prompt_challenge_mentions_key_concerns(self, tmp_path: Path):
+        """Challenge should mention overfitting, lookahead, data leakage."""
+        prompt = self._build_prompt(tmp_path)
+        prompt_lower = prompt.lower()
+        found = sum(
+            1
+            for term in ["overfitting", "lookahead", "leakage"]
+            if term in prompt_lower
+        )
+        assert (
+            found >= 2
+        ), f"Expected at least 2 of [overfitting, lookahead, leakage], found {found}"
+
+    def test_prompt_challenge_is_pre_execution(self, tmp_path: Path):
+        """Challenge should happen before execute_experiment."""
+        prompt = self._build_prompt(tmp_path)
+        prompt_lower = prompt.lower()
+        assert "before" in prompt_lower
+        assert "execute" in prompt_lower or "execution" in prompt_lower
+
+    def test_prompt_challenge_default_for_full_squad(self, tmp_path: Path):
+        """Design challenge should be default for full_squad cadence."""
+        prompt = self._build_prompt(tmp_path, cadence="full_squad")
+        prompt_lower = prompt.lower()
+        assert "full_squad" in prompt_lower or "default" in prompt_lower
+
+    def test_prompt_challenge_skippable_for_quick_iteration(self, tmp_path: Path):
+        """Design challenge should be skippable for quick_iteration cadence."""
+        prompt = self._build_prompt(tmp_path)
+        prompt_lower = prompt.lower()
+        assert "quick_iteration" in prompt_lower
+        assert "skip" in prompt_lower
+
+
+class TestM3DebateDepthHeuristics:
+    """Director prompt includes when to continue/resolve debates."""
+
+    def _build_prompt(self, tmp_path, cadence="full_squad"):
+        charter = tmp_path / "charter.md"
+        charter.write_text("You are the Director.")
+        return build_director_prompt(
+            charter_path=charter,
+            iteration=1,
+            cadence=cadence,
+            nudges="",
+        )
+
+    def test_prompt_has_continue_heuristics(self, tmp_path: Path):
+        """Prompt describes when to continue a debate."""
+        prompt = self._build_prompt(tmp_path)
+        prompt_lower = prompt.lower()
+        assert "continue" in prompt_lower
+        # Should mention factual concerns or unaddressed points
+        assert (
+            "factual" in prompt_lower
+            or "addressed" in prompt_lower
+            or "unaddressed" in prompt_lower
+        )
+
+    def test_prompt_has_resolve_heuristics(self, tmp_path: Path):
+        """Prompt describes when to resolve/end a debate."""
+        prompt = self._build_prompt(tmp_path)
+        prompt_lower = prompt.lower()
+        assert "resolve" in prompt_lower or "stop" in prompt_lower
+        # Should mention repetition or preference-based disagreement
+        assert "repeating" in prompt_lower or "preference" in prompt_lower
+
+    def test_prompt_mentions_turn_limit(self, tmp_path: Path):
+        """Prompt warns about the 5-turn maximum enforced by Python."""
+        prompt = self._build_prompt(tmp_path)
+        assert "5" in prompt
+        # Should mention the limit is enforced
+        assert "limit" in prompt.lower() or "maximum" in prompt.lower()
+
+    def test_prompt_has_token_budget_guidance(self, tmp_path: Path):
+        """Prompt includes token cost guidance for debate turns."""
+        prompt = self._build_prompt(tmp_path)
+        # Should mention token cost per turn
+        assert "token" in prompt.lower() or "budget" in prompt.lower()
+
     def test_conversation_log_includes_director_reasoning(self, tmp_path: Path):
         """Log should include the Director's own text reasoning."""
         result = CycleResult(
             iteration=1,
             director_transcript=[
-                {"role": "assistant", "type": "text",
-                 "content": "Frontiers show 5m EURUSD is promising but costly. I'll consult Quant first."},
+                {
+                    "role": "assistant",
+                    "type": "text",
+                    "content": "Frontiers show 5m EURUSD is promising but costly. I'll consult Quant first.",
+                },
             ],
         )
 

--- a/tests/unit/squad/test_squad_tools.py
+++ b/tests/unit/squad/test_squad_tools.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 # Ensure .squad/ is on sys.path
 _squad_dir = str(Path(__file__).resolve().parents[3] / ".squad")
 if _squad_dir not in sys.path:
@@ -16,6 +18,8 @@ from squad_engine.squad_tools import (  # noqa: E402
     CycleState,
     create_squad_mcp_server,
 )
+
+from ktrdr.agents.runtime.protocol import AgentResult  # noqa: E402
 
 
 class TestCycleState:
@@ -146,3 +150,237 @@ class TestM2SpawnAgentSchema:
             or "consultant" in desc.lower()
             or "all" in desc.lower()
         )
+
+
+# ---------------------------------------------------------------------------
+# M3: Debate Depth Control — Turn Pair Tracking + Safety Valve
+# ---------------------------------------------------------------------------
+
+
+class TestM3DebateTurnPairTracking:
+    """CycleState tracks debate turn pairs and enforces limits."""
+
+    def test_debate_pairs_initialized_empty(self):
+        """Fresh CycleState has empty debate pair tracking."""
+        state = CycleState()
+        assert state.debate_pairs == {}
+
+    def test_debate_pairs_track_role_pairs(self):
+        """record_debate_turn tracks turns between role pairs."""
+        state = CycleState()
+        state.record_debate_turn("engineer", "critic")
+        assert state.debate_pairs[("critic", "engineer")] == 1
+
+    def test_debate_pairs_increment_on_repeated_turn(self):
+        """Multiple turns between same pair increment the count."""
+        state = CycleState()
+        state.record_debate_turn("engineer", "critic")
+        state.record_debate_turn("critic", "engineer")
+        state.record_debate_turn("engineer", "critic")
+        # All three are the same pair (sorted)
+        assert state.debate_pairs[("critic", "engineer")] == 3
+
+    def test_debate_pairs_sorted_key(self):
+        """Pair key is sorted so (A,B) == (B,A)."""
+        state = CycleState()
+        state.record_debate_turn("engineer", "critic")
+        state.record_debate_turn("critic", "engineer")
+        # Only one key, sorted alphabetically
+        assert len(state.debate_pairs) == 1
+        assert ("critic", "engineer") in state.debate_pairs
+
+    def test_different_pairs_tracked_independently(self):
+        """engineer↔critic and engineer↔inventor are separate pairs."""
+        state = CycleState()
+        state.record_debate_turn("engineer", "critic")
+        state.record_debate_turn("engineer", "critic")
+        state.record_debate_turn("engineer", "inventor")
+        assert state.debate_pairs[("critic", "engineer")] == 2
+        assert state.debate_pairs[("engineer", "inventor")] == 1
+
+    def test_is_debate_limit_reached_false_under_limit(self):
+        """Under 5 turns: limit not reached."""
+        state = CycleState()
+        for _ in range(4):
+            state.record_debate_turn("engineer", "critic")
+        assert not state.is_debate_limit_reached("engineer", "critic")
+
+    def test_is_debate_limit_reached_true_at_limit(self):
+        """At 5 turns: limit reached."""
+        state = CycleState()
+        for _ in range(5):
+            state.record_debate_turn("engineer", "critic")
+        assert state.is_debate_limit_reached("engineer", "critic")
+
+    def test_is_debate_limit_reached_false_for_untracked_pair(self):
+        """Pair with no turns: limit not reached."""
+        state = CycleState()
+        assert not state.is_debate_limit_reached("engineer", "architect")
+
+
+class TestM3DebateMetadata:
+    """CycleState tracks debate metadata for CycleResult."""
+
+    def test_debates_list_initialized_empty(self):
+        """Fresh CycleState has empty debates list."""
+        state = CycleState()
+        assert state.debates == []
+
+    def test_record_debate_adds_metadata(self):
+        """record_debate stores structured debate metadata."""
+        state = CycleState()
+        state.record_debate(
+            roles=["engineer", "critic"],
+            turns=3,
+            revised=True,
+            resolution="Engineer removed 4 correlated features",
+        )
+        assert len(state.debates) == 1
+        debate = state.debates[0]
+        assert debate["roles"] == ["engineer", "critic"]
+        assert debate["turns"] == 3
+        assert debate["revised"] is True
+        assert "correlated features" in debate["resolution"]
+
+    def test_multiple_debates_recorded(self):
+        """Multiple debates in one cycle are all recorded."""
+        state = CycleState()
+        state.record_debate(
+            roles=["engineer", "critic"],
+            turns=3,
+            revised=True,
+            resolution="Feature count reduced",
+        )
+        state.record_debate(
+            roles=["engineer", "inventor"],
+            turns=2,
+            revised=False,
+            resolution="Kept original approach — inventor's idea deferred to future cycle",
+        )
+        assert len(state.debates) == 2
+
+
+# ---------------------------------------------------------------------------
+# M3: spawn_agent Debate Enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestM3SpawnAgentDebateEnforcement:
+    """spawn_agent tool tracks debate turns and enforces the 5-turn limit."""
+
+    def _make_tool_handler(self, mock_manager, cycle_state):
+        """Create the spawn_agent tool handler via create_squad_mcp_server."""
+        captured_handlers = {}
+
+        with patch("squad_engine.session._get_sdk") as mock_sdk_fn:
+            mock_sdk = MagicMock()
+
+            def capture_tool(**kw):
+                name = kw.get("name", "")
+
+                def decorator(fn):
+                    captured_handlers[name] = fn
+                    return fn
+
+                return decorator
+
+            mock_sdk.tool = capture_tool
+            mock_sdk.create_sdk_mcp_server = MagicMock(return_value={"type": "sdk"})
+            mock_sdk_fn.return_value = mock_sdk
+
+            create_squad_mcp_server(
+                agent_manager=mock_manager,
+                cycle_state=cycle_state,
+            )
+
+        return captured_handlers.get("spawn_agent")
+
+    def _make_mock_manager(self):
+        mock = AsyncMock()
+        mock.spawn_agent = AsyncMock(
+            return_value=AgentResult(
+                output="Response from agent.",
+                cost_usd=0.05,
+                turns=1,
+                transcript=[],
+                session_id="sess_1",
+            )
+        )
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_consecutive_different_roles_records_debate_turn(self):
+        """Spawning role B after role A records a debate turn for that pair."""
+        state = CycleState()
+        mock_manager = self._make_mock_manager()
+        handler = self._make_tool_handler(mock_manager, state)
+
+        await handler({"role": "engineer", "message": "Design strategy"})
+        await handler({"role": "critic", "message": "Challenge it"})
+
+        assert state.debate_pairs.get(("critic", "engineer"), 0) == 1
+
+    @pytest.mark.asyncio
+    async def test_same_role_twice_no_debate_turn(self):
+        """Spawning the same role twice doesn't create a debate turn."""
+        state = CycleState()
+        mock_manager = self._make_mock_manager()
+        handler = self._make_tool_handler(mock_manager, state)
+
+        await handler({"role": "engineer", "message": "First"})
+        await handler({"role": "engineer", "message": "Second"})
+
+        assert state.debate_pairs == {}
+
+    @pytest.mark.asyncio
+    async def test_debate_limit_returns_message_instead_of_spawning(self):
+        """After 5 turns, spawn_agent returns a limit message without calling the agent."""
+        state = CycleState()
+        mock_manager = self._make_mock_manager()
+        handler = self._make_tool_handler(mock_manager, state)
+
+        # Simulate 5 turns of engineer↔critic debate
+        for _ in range(5):
+            state.record_debate_turn("engineer", "critic")
+
+        # Set last_spawned_role so the next spawn triggers the pair check
+        state.last_spawned_role = "engineer"
+
+        result = await handler({"role": "critic", "message": "One more challenge"})
+
+        # Should return limit message, NOT call the agent
+        assert "limit" in result["output"].lower() or "5" in result["output"]
+        # spawn_agent should NOT have been called for the limited pair
+        # (it was called 0 times because we set up debate_pairs manually)
+        mock_manager.spawn_agent.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_debate_limit_only_affects_limited_pair(self):
+        """Limit on engineer↔critic doesn't block engineer↔inventor."""
+        state = CycleState()
+        mock_manager = self._make_mock_manager()
+        handler = self._make_tool_handler(mock_manager, state)
+
+        # Max out engineer↔critic
+        for _ in range(5):
+            state.record_debate_turn("engineer", "critic")
+
+        # Spawn inventor after engineer — different pair, should work
+        state.last_spawned_role = "engineer"
+        result = await handler({"role": "inventor", "message": "New ideas"})
+
+        assert result["output"] == "Response from agent."
+        mock_manager.spawn_agent.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_last_spawned_role_tracked(self):
+        """CycleState.last_spawned_role updated after each spawn."""
+        state = CycleState()
+        mock_manager = self._make_mock_manager()
+        handler = self._make_tool_handler(mock_manager, state)
+
+        assert state.last_spawned_role is None
+        await handler({"role": "engineer", "message": "Hello"})
+        assert state.last_spawned_role == "engineer"
+        await handler({"role": "critic", "message": "Challenge"})
+        assert state.last_spawned_role == "critic"


### PR DESCRIPTION
## Summary

- Enable Director-mediated multi-turn debates between agents (Engineer ↔ Critic design challenge)
- Add debate relay pattern, depth control heuristics, and 5-turn safety valve to Director prompt and Python enforcement
- Battle-tested through 3 E2E runs with real Claude sessions — prompt iterated from advisory → mandatory → anti-bypass based on actual Director behavior

## What changed

**Director prompt** (`director_prompt.py`):
- `DEBATE_RELAY` section: numbered relay flow, good/bad synthesis examples, continue/resolve heuristics, 5-turn limit
- `DESIGN_CHALLENGE` section: mandatory pre-execution Critic review in full_squad mode, anti-bypass language
- Full_squad task instructions reference mandatory design challenge

**Python enforcement** (`squad_tools.py`, `agent_manager.py`, `loop.py`):
- `AgentManager.query_counts` — per-role query tracking, reset on teardown
- `CycleState.debate_pairs` — turn pair tracking with sorted keys
- `CycleState.record_debate_turn()` / `is_debate_limit_reached()` — 5-turn safety valve
- `spawn_agent_tool` — auto-records debate turns, returns limit message when exceeded
- `CycleResult.debates` field wired from CycleState

**E2E test recipe**: `squad/m3-debate-genuine-revision.md` — validates full E→C→E relay with real Claude sessions

## E2E validation

| Run | Iteration | Result | Root cause |
|-----|-----------|--------|------------|
| 1 | 300 | FAILED | Director used Critic for retrospective analysis, never challenged new design |
| 2 | 301 | FAILED | Director called Critic but self-applied framework instead of relaying |
| 3 | 302 | **PASSED** | Full E→C→E relay — Director synthesized Critic's concerns and relayed to Engineer |

Key learning: LLM Directors need explicit anti-bypass language ("Do NOT apply the Critic's framework yourself"), not just mandatory directives.

## Test plan

- [x] 103 unit tests passing (31 new for M3)
- [x] Lint + format clean
- [x] E2E validated with real Claude sessions (iteration=302 PASSED)
- [x] No regressions in existing M1/M2 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)