### PR TITLE
docs: Earnings Play Analyzer — design + implementation plan

### DIFF
--- a/docs/designs/earnings-play-analyzer/ARCHITECTURE.md
+++ b/docs/designs/earnings-play-analyzer/ARCHITECTURE.md
@@ -1,0 +1,583 @@
+# Earnings Play Analyzer — Architecture Document
+
+## 1. System Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     CLI Interface (Click)                       │
+│  epa analyze | epa review | epa calibration | epa upcoming     │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     Orchestrator                                │
+│  Routes commands, manages workflow, handles errors              │
+└───┬──────────┬──────────┬──────────┬──────────┬────────────────┘
+    │          │          │          │          │
+    ▼          ▼          ▼          ▼          ▼
+┌────────┐┌────────┐┌─────────┐┌────────┐┌──────────┐
+│  Data  ││Analysis││  Opus   ││ ktrdr  ││  Store   │
+│ Layer  ││ Engine ││Reasoner ││Adapter ││  (DB)    │
+└────────┘└────────┘└─────────┘└────────┘└──────────┘
+    │                    │          │
+    ▼                    ▼          ▼
+┌────────┐         ┌─────────┐┌────────┐
+│yfinance│         │Anthropic││ ktrdr  │
+│  IBKR  │         │  API    ││ signal │
+│  (M5)  │         └─────────┘│  file  │
+└────────┘                    └────────┘
+```
+
+## 2. Component Design
+
+### 2.1 CLI Interface (`epa/cli.py`)
+
+Framework: **Click** (standard Python CLI framework, already common in Karl's stack)
+
+Responsibilities:
+- Parse commands and arguments
+- Format output for terminal (rich tables, colored text)
+- Handle `--json` flag for machine-readable output
+
+Dependencies: `click`, `rich` (for formatted output)
+
+```python
+# Command structure
+@click.group()
+def cli(): ...
+
+@cli.command()
+@click.argument('ticker')
+@click.option('--budget', type=float, help='Account size in USD')
+@click.option('--signal', help='Manual signal override: BUY:0.73')
+@click.option('--json', 'output_json', is_flag=True)
+def analyze(ticker, budget, signal, output_json): ...
+
+@cli.command()
+@click.argument('ticker')
+def review(ticker): ...
+
+@cli.command()
+def calibration(): ...
+
+@cli.command()
+def upcoming(): ...
+```
+
+### 2.2 Data Layer (`epa/data/`)
+
+Responsible for all external data acquisition. Returns normalized data objects regardless of source.
+
+#### `epa/data/models.py` — Data Models
+
+```python
+@dataclass
+class EarningsEvent:
+    ticker: str
+    date: datetime
+    time_of_day: str          # "BMO" | "AMC" | "UNKNOWN"
+    actual_move_pct: float | None   # None if not yet occurred
+    direction: int | None           # +1 or -1
+
+@dataclass
+class EarningsHistory:
+    ticker: str
+    events: list[EarningsEvent]
+    avg_move: float
+    median_move: float
+    max_move: float
+    min_move: float
+    stdev_move: float
+    up_pct: float             # % of events that moved up
+
+@dataclass
+class OptionsSnapshot:
+    ticker: str
+    underlying_price: float
+    timestamp: datetime
+    expiry: date
+    calls: list[OptionQuote]
+    puts: list[OptionQuote]
+    atm_straddle_price: float
+    implied_move_pct: float
+
+@dataclass
+class OptionQuote:
+    strike: float
+    bid: float
+    ask: float
+    mid: float
+    iv: float
+    delta: float
+    gamma: float
+    theta: float
+    vega: float
+    volume: int
+    open_interest: int
+
+@dataclass
+class IVData:
+    ticker: str
+    current_iv: float
+    iv_52w_high: float
+    iv_52w_low: float
+    iv_rank: float            # 0-100
+    iv_percentile: float      # 0-100
+    iv_history: list[tuple[date, float]]  # for charting
+```
+
+#### `epa/data/providers/yfinance_provider.py`
+
+```python
+class YFinanceProvider:
+    def get_earnings_history(self, ticker: str, quarters: int = 16) -> EarningsHistory
+    def get_options_snapshot(self, ticker: str, target_expiry: date | None = None) -> OptionsSnapshot
+    def get_iv_data(self, ticker: str) -> IVData
+    def get_next_earnings_date(self, ticker: str) -> EarningsEvent | None
+```
+
+#### `epa/data/providers/ibkr_provider.py` (M5)
+
+Same interface as YFinanceProvider, but backed by IBKR TWS/Gateway API.
+
+#### `epa/data/providers/vision_provider.py` (M3)
+
+```python
+class VisionProvider:
+    def extract_options_chain(self, image_path: str) -> OptionsSnapshot
+    # Uses Opus 4.7 vision to extract structured data from screenshot
+```
+
+#### `epa/data/provider.py` — Provider interface + factory
+
+```python
+class DataProvider(Protocol):
+    def get_earnings_history(self, ticker: str, quarters: int = 16) -> EarningsHistory: ...
+    def get_options_snapshot(self, ticker: str, target_expiry: date | None = None) -> OptionsSnapshot: ...
+    def get_iv_data(self, ticker: str) -> IVData: ...
+    def get_next_earnings_date(self, ticker: str) -> EarningsEvent | None: ...
+```
+
+### 2.3 Analysis Engine (`epa/analysis/`)
+
+Pure computation — no external calls, no LLM, fully testable with synthetic data.
+
+#### `epa/analysis/edge.py`
+
+```python
+class EdgeCalculator:
+    def compute_edge(self, history: EarningsHistory, snapshot: OptionsSnapshot) -> EdgeEstimate
+    # Returns: edge_pct, direction (long_vol | short_vol), confidence
+
+    def estimate_iv_crush(self, iv_data: IVData, snapshot: OptionsSnapshot) -> float
+    # Estimates post-earnings IV as min(current_iv * 0.5, pre_runup_iv)
+    # Used to improve short premium structure scoring
+
+@dataclass
+class EdgeEstimate:
+    edge_pct: float           # positive = long vol edge, negative = short vol
+    direction: str            # "long_vol" | "short_vol"
+    confidence: float         # 0-1, based on sample size and consistency
+    iv_crush_estimate: float  # expected IV drop post-earnings (percentage points)
+    rationale: str            # human-readable explanation
+```
+
+#### `epa/analysis/sizing.py`
+
+```python
+class KellySizer:
+    def compute_size(
+        self,
+        edge: EdgeEstimate,
+        structure: OptionsStructure,
+        account_size: float,
+        max_risk_pct: float = 2.0,
+        kelly_fraction: float = 0.5
+    ) -> SizingResult
+
+@dataclass
+class SizingResult:
+    contracts: int
+    capital_at_risk: float
+    risk_pct: float           # of account
+    kelly_raw: float          # raw Kelly fraction
+    kelly_applied: float      # after half-Kelly and cap
+    rationale: str
+```
+
+#### `epa/analysis/structures.py`
+
+```python
+class StructureSelector:
+    def select_candidates(
+        self,
+        edge: EdgeEstimate,
+        snapshot: OptionsSnapshot,
+        history: EarningsHistory,
+        signal: KtrdrSignal | None = None
+    ) -> list[OptionsStructure]
+    # Returns ranked list of candidate structures scored by expected value:
+    #   EV = prob_profit * avg_profit - prob_loss * avg_loss
+    # Uses historical move distribution to estimate prob_profit per structure
+
+@dataclass
+class OptionsStructure:
+    name: str                 # "long_straddle", "bull_put_spread", etc.
+    legs: list[OptionLeg]
+    max_profit: float | None  # None if unlimited
+    max_loss: float
+    breakeven: list[float]    # 1 or 2 breakeven points
+    score: float              # 0-1, higher is better match
+    rationale: str
+
+@dataclass
+class OptionLeg:
+    side: str                 # "buy" | "sell"
+    option_type: str          # "call" | "put"
+    strike: float
+    expiry: date
+    quantity: int
+    premium: float            # per contract
+```
+
+### 2.4 Opus Reasoner (`epa/reasoner/`)
+
+Thin wrapper around Claude API that sends structured data and receives structured + narrative output.
+
+#### `epa/reasoner/opus.py`
+
+```python
+class OpusReasoner:
+    def __init__(self, api_key: str, model: str = "claude-opus-4-6"):
+        self.client = anthropic.Anthropic(api_key=api_key)
+        self.model = model
+
+    def reason_about_trade(
+        self,
+        history: EarningsHistory,
+        iv_data: IVData,
+        edge: EdgeEstimate,
+        candidates: list[OptionsStructure],
+        sizing: SizingResult,
+        signal: KtrdrSignal | None = None
+    ) -> TradeRecommendation:
+        # Constructs structured prompt with all data
+        # Returns final recommendation with natural language rationale
+
+    def extract_from_screenshot(self, image_path: str) -> OptionsSnapshot:
+        # Vision-based extraction
+
+@dataclass
+class TradeRecommendation:
+    ticker: str
+    earnings_date: datetime
+    action: str               # "TRADE" | "SKIP"
+    structure: OptionsStructure | None
+    sizing: SizingResult | None
+    rationale: str            # Natural language explanation
+    confidence: float         # 0-1
+    risk_factors: list[str]   # Key risks to be aware of
+    raw_data: dict            # All input data for audit trail
+```
+
+**Prompt design**: The system prompt establishes the role (experienced options trader analyzing earnings), the input format (structured JSON), and the expected output format (JSON + rationale). The prompt includes:
+1. All historical earnings data
+2. Current IV data and snapshot
+3. Computed edge estimate
+4. Candidate structures with scores
+5. Kelly sizing calculation
+6. ktrdr signal (if available)
+
+Opus is asked to:
+1. Validate or challenge the edge estimate
+2. Select the best structure from candidates (or propose an alternative)
+3. Confirm or adjust sizing
+4. Provide narrative rationale connecting all factors
+
+### 2.5 ktrdr Adapter (`epa/integrations/ktrdr.py`)
+
+```python
+class KtrdrAdapter:
+    def __init__(self, signal_dir: str = "~/.ktrdr/signals/"):
+        self.signal_dir = Path(signal_dir).expanduser()
+
+    def get_signal(self, ticker: str) -> KtrdrSignal | None:
+        # Read from {signal_dir}/{TICKER}.json
+        # Return None if file doesn't exist or is stale (> 24h old)
+
+    def is_available(self) -> bool:
+        # Check if signal directory exists
+
+@dataclass
+class KtrdrSignal:
+    ticker: str
+    signal: str               # "BUY" | "SELL" | "HOLD"
+    confidence: float         # 0-1
+    timestamp: datetime
+    model_version: str | None
+```
+
+**Staleness**: Signals older than 24 hours are discarded (earnings setups change fast). Configurable.
+
+### 2.6 Store (`epa/store/`)
+
+#### `epa/store/db.py`
+
+```python
+class EpaStore:
+    def __init__(self, db_path: str = "~/.epa/epa.db"):
+        self.db = sqlite3.connect(Path(db_path).expanduser())
+        self._init_schema()
+
+    # Predictions
+    def save_prediction(self, rec: TradeRecommendation) -> int
+    def get_prediction(self, ticker: str, earnings_date: date) -> TradeRecommendation | None
+
+    # Actuals
+    def save_actual(self, ticker: str, earnings_date: date, actual_move: float, pnl: float | None)
+
+    # Calibration
+    def get_calibration_stats(self) -> CalibrationStats
+    def get_ticker_history(self, ticker: str) -> list[PredictionActualPair]
+
+    # Config
+    def get_config(self, key: str) -> str | None
+    def set_config(self, key: str, value: str)
+
+    # Watchlist
+    def get_watchlist(self) -> list[str]
+    def add_to_watchlist(self, ticker: str)
+    def remove_from_watchlist(self, ticker: str)
+
+    # IV history cache
+    def cache_iv_history(self, ticker: str, data: list[tuple[date, float]])
+    def get_cached_iv_history(self, ticker: str) -> list[tuple[date, float]] | None
+```
+
+#### SQLite Schema
+
+```sql
+CREATE TABLE predictions (
+    id INTEGER PRIMARY KEY,
+    ticker TEXT NOT NULL,
+    earnings_date DATE NOT NULL,
+    analysis_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    action TEXT NOT NULL,           -- TRADE or SKIP
+    structure_name TEXT,
+    structure_json TEXT,            -- full OptionsStructure as JSON
+    edge_pct REAL,
+    kelly_fraction REAL,
+    contracts INTEGER,
+    capital_at_risk REAL,
+    rationale TEXT,
+    confidence REAL,
+    ktrdr_signal TEXT,              -- BUY/SELL/HOLD or NULL
+    ktrdr_confidence REAL,
+    raw_data_json TEXT,             -- complete input data for audit
+    UNIQUE(ticker, earnings_date)
+);
+
+CREATE TABLE actuals (
+    id INTEGER PRIMARY KEY,
+    ticker TEXT NOT NULL,
+    earnings_date DATE NOT NULL,
+    actual_move_pct REAL NOT NULL,
+    actual_direction INTEGER,       -- +1 or -1
+    pnl REAL,                       -- actual P&L if traded
+    notes TEXT,
+    FOREIGN KEY (ticker, earnings_date)
+        REFERENCES predictions(ticker, earnings_date)
+);
+
+CREATE TABLE config (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE watchlist (
+    ticker TEXT PRIMARY KEY,
+    added_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE iv_cache (
+    ticker TEXT NOT NULL,
+    date DATE NOT NULL,
+    iv_value REAL NOT NULL,
+    cached_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (ticker, date)
+);
+
+CREATE TABLE data_cache (
+    cache_key TEXT PRIMARY KEY,      -- e.g., "options:AAPL:2026-04-25"
+    data_json TEXT NOT NULL,
+    cached_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    ttl_seconds INTEGER NOT NULL     -- 900 for options, 86400 for earnings history
+);
+```
+
+## 3. Data Flow — Full Scenario
+
+### 3.1 `epa analyze AAPL --budget 65000`
+
+```
+1. CLI parses args: ticker=AAPL, budget=65000
+2. Orchestrator begins:
+   a. store.get_config("account_size") → fallback to --budget
+   b. provider.get_next_earnings_date("AAPL") → 2026-04-24 AMC
+   c. provider.get_earnings_history("AAPL", quarters=16) → EarningsHistory
+   d. provider.get_options_snapshot("AAPL", target_expiry=2026-04-25) → OptionsSnapshot
+   e. provider.get_iv_data("AAPL") → IVData
+   f. ktrdr_adapter.get_signal("AAPL") → KtrdrSignal | None
+3. Analysis engine:
+   a. edge_calc.compute_edge(history, snapshot) → EdgeEstimate
+   b. structure_selector.select_candidates(edge, snapshot, signal) → list[OptionsStructure]
+   c. For each candidate: kelly_sizer.compute_size(edge, structure, budget) → SizingResult
+4. Opus reasoner:
+   a. opus.reason_about_trade(history, iv_data, edge, candidates, sizing, signal) → TradeRecommendation
+5. Output:
+   a. store.save_prediction(recommendation)
+   b. CLI formats and prints recommendation
+```
+
+### 3.2 Error Handling
+
+| Failure | Behavior |
+|---------|----------|
+| yfinance rate limited / down | Retry 3x with exponential backoff, then fail with clear message |
+| No earnings date found | "No upcoming earnings found for {ticker}. Check the ticker symbol." |
+| Options chain empty | "No options data available for {ticker}. Options may not be listed or market may be closed." |
+| ktrdr signal unavailable | Proceed without signal, note in output: "No directional signal — using neutral assumption" |
+| ktrdr signal stale (>24h) | Same as unavailable |
+| Anthropic API error | Retry 2x, then fall back to rule-based recommendation without Opus narrative |
+| IV history insufficient (<30 days) | Use available data, flag low confidence in IV rank calculation |
+| SQLite write failure | Log warning, continue (analysis is primary, storage is secondary) |
+
+### 3.3 Fallback Mode (No Opus)
+
+If Anthropic API is unavailable, the system still produces a recommendation using pure rules:
+1. Edge > 0 + no signal → long straddle
+2. Edge > 0 + BUY signal → bull call spread
+3. Edge > 0 + SELL signal → bear put spread
+4. Edge < 0 + no signal → short iron condor
+5. Edge < 0 + directional signal → skip (conflicting signals)
+
+Rationale is template-based instead of LLM-generated. Clearly marked as "rule-based recommendation (Opus unavailable)".
+
+## 4. Project Structure
+
+```
+epa/
+├── __init__.py
+├── __main__.py              # python -m epa
+├── cli.py                   # Click CLI
+├── orchestrator.py          # Main workflow coordination
+├── config.py                # Config management
+├── data/
+│   ├── __init__.py
+│   ├── models.py            # All dataclasses
+│   ├── provider.py          # DataProvider protocol
+│   └── providers/
+│       ├── __init__.py
+│       ├── yfinance_provider.py
+│       ├── ibkr_provider.py     # M5
+│       └── vision_provider.py   # M3
+├── analysis/
+│   ├── __init__.py
+│   ├── edge.py              # Edge computation
+│   ├── sizing.py            # Kelly criterion sizing
+│   └── structures.py        # Structure selection
+├── reasoner/
+│   ├── __init__.py
+│   ├── opus.py              # Opus 4.7 integration
+│   └── prompts.py           # Prompt templates
+├── integrations/
+│   ├── __init__.py
+│   └── ktrdr.py             # ktrdr signal adapter
+├── store/
+│   ├── __init__.py
+│   └── db.py                # SQLite store
+└── tests/
+    ├── __init__.py
+    ├── test_edge.py
+    ├── test_sizing.py
+    ├── test_structures.py
+    ├── test_yfinance_provider.py
+    ├── test_orchestrator.py
+    └── fixtures/             # Sample data for tests
+        ├── aapl_earnings.json
+        ├── aapl_options.json
+        └── sample_signal.json
+```
+
+## 5. Dependencies
+
+### Core (MVP)
+```
+click>=8.0          # CLI framework
+rich>=13.0          # Terminal formatting
+yfinance>=0.2.36    # Market data
+anthropic>=0.40     # Opus 4.7 API
+```
+
+### Development
+```
+pytest>=8.0
+pytest-cov
+ruff                # Linting
+```
+
+### M5 Additions
+```
+ib_insync>=0.9      # IBKR TWS API (or ibapi)
+```
+
+## 6. Configuration
+
+Stored in `~/.epa/config.toml` (human-readable) and `~/.epa/epa.db` (runtime state).
+
+```toml
+[account]
+size = 65000.0
+max_risk_pct = 2.0
+kelly_fraction = 0.5
+
+[data]
+provider = "yfinance"           # "yfinance" | "ibkr"
+history_quarters = 16
+iv_cache_days = 1               # re-fetch IV history daily
+
+[ktrdr]
+enabled = true
+signal_dir = "~/.ktrdr/signals"
+max_signal_age_hours = 24
+
+[opus]
+model = "claude-opus-4-6"
+max_tokens = 4096
+enabled = true                  # false = rule-based only
+
+[ibkr]                          # M5
+host = "127.0.0.1"
+port = 7497                     # 7497=paper, 7496=live
+client_id = 1
+```
+
+## 7. Security Considerations
+
+- **API keys**: Anthropic API key stored in environment variable `ANTHROPIC_API_KEY`, never in config files
+- **IBKR credentials**: Handled by TWS/Gateway, not by this tool
+- **No credentials in SQLite**: DB stores analysis data only
+- **Paper trading default**: IBKR integration (M5) defaults to paper trading port (7497). Live trading requires explicit `--live` flag
+
+## 8. Deployment
+
+### MVP (Mac laptop)
+- `pip install -e .` in a virtualenv
+- `epa` command available in PATH
+- Data stored in `~/.epa/`
+
+### Production (Azure ACA) — future
+- Containerized with Docker
+- SQLite → PostgreSQL migration
+- Telegram bot or web API frontend
+- Scheduled scans of watchlist before earnings

--- a/docs/designs/earnings-play-analyzer/DESIGN.md
+++ b/docs/designs/earnings-play-analyzer/DESIGN.md
@@ -1,0 +1,334 @@
+# Earnings Play Analyzer — Design Document
+
+## 1. Problem Statement
+
+Options traders face a recurring challenge before every earnings announcement: **Should I trade this event? If yes, what structure? How much capital?** This decision requires synthesizing multiple data streams (historical moves, implied volatility, directional signals) under time pressure, and most traders do this ad hoc.
+
+The Earnings Play Analyzer systematizes this workflow into a repeatable, data-driven process that combines:
+- Historical earnings move analysis (what usually happens)
+- Current implied volatility assessment (what the market is pricing)
+- Optional ML directional signal from ktrdr (which way)
+- Kelly criterion sizing (how much)
+
+The output is a **concrete, sized options trade recommendation with rationale**.
+
+## 2. Core Workflow
+
+```
+Ticker + (optional) ktrdr signal + (optional) risk budget
+    │
+    ▼
+┌──────────────────────────┐
+│  1. Data Acquisition     │  ← yfinance, IBKR, or screenshot
+│     - Historical moves   │
+│     - Current IV / chain │
+│     - Earnings date      │
+└──────────┬───────────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  2. Edge Computation     │  ← Pure math, no LLM
+│     - IV rank / %ile     │
+│     - Implied vs actual  │
+│     - Edge estimate      │
+│     - Kelly sizing       │
+└──────────┬───────────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  3. Structure Selection  │  ← Rule engine + Opus reasoning
+│     - Filter candidates  │
+│     - Score structures   │
+│     - Apply directional  │
+│       signal (if avail)  │
+└──────────┬───────────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  4. Recommendation       │  ← Opus 4.7 reasoning
+│     - Final structure    │
+│     - Position size      │
+│     - Risk parameters    │
+│     - Natural language    │
+│       rationale          │
+└──────────┬───────────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  5. Tracking (optional)  │
+│     - Record prediction  │
+│     - Post-earnings:     │
+│       actual vs predicted│
+│     - Calibration update │
+└──────────────────────────┘
+```
+
+## 3. Data Sources
+
+### 3.1 Historical Earnings Data
+
+| Source | Pro | Con | Decision |
+|--------|-----|-----|----------|
+| yfinance | Free, Python-native, has earnings dates + historical prices | No direct "earnings move" data — must compute from price history | **MVP choice** |
+| Earnings Whispers / similar scrapers | Dedicated earnings data | Fragile, TOS concerns | Skip |
+| IBKR historical data | Authoritative, integrated | Requires IBKR connection | M5 |
+
+**MVP approach**: Use yfinance to fetch earnings dates (via `ticker.earnings_dates` or `ticker.calendar`), then compute actual moves from daily OHLC around each earnings date. This gives us 8-20 quarters of historical earnings move data for most tickers.
+
+**[DECISION POINT]**: yfinance for MVP. Migrate to IBKR historical data in M5 for better reliability and options-specific historical data.
+
+### 3.2 Implied Volatility Data
+
+| Source | Pro | Con | Decision |
+|--------|-----|-----|----------|
+| yfinance options chains | Free, Python-native | IV values can be stale/inaccurate | **MVP choice** |
+| IBKR live options data | Real-time, accurate Greeks | Requires connection | M5 |
+| CBOE data | Authoritative | Paid, complex access | Skip |
+| Broker screenshot + Opus vision | No API needed, flexible | Manual step, not automatable | **Fallback** |
+
+**MVP approach**: yfinance `ticker.option_chain()` provides per-strike IVs. Compute IV rank from 1-year IV history (via VIX for index, or ATM straddle approximation for individual stocks).
+
+**Bootstrap limitation**: IV rank requires ~252 trading days of IV history. On first use, this data doesn't exist. The system will: (a) for S&P 500 components, approximate IV rank from VIX percentile as a bootstrap; (b) for other tickers, report "insufficient IV history" until enough data accumulates (~2 weeks of daily caching). The output clearly flags when IV rank is bootstrapped or unavailable.
+
+### 3.3 ktrdr Signal
+
+ktrdr produces: `{ signal: BUY|SELL|HOLD, confidence: 0.0-1.0, timestamp }`.
+
+**Integration approach**: Loose coupling via file or REST API. ktrdr writes its latest signal to a known location (JSON file or HTTP endpoint). The analyzer reads it if available, proceeds without it if not.
+
+**[DECISION POINT]**: File-based integration for MVP (ktrdr writes `~/.ktrdr/signals/{TICKER}.json`). REST API in M4. Direct Python import avoided — ktrdr has its own dependency tree and runtime.
+
+### 3.4 Opus 4.7
+
+**Role**: Reasoning engine, not data engine. Receives structured data (numbers, computed metrics), produces:
+1. Structure selection rationale (why this spread over that straddle)
+2. Risk assessment narrative
+3. Final recommendation in natural language + structured JSON
+
+**Secondary role**: Vision-based data extraction from broker screenshots (fallback when APIs unavailable).
+
+**[DECISION POINT]**: Opus is called via Anthropic API with structured prompts. Input is always structured data (JSON). Output is structured JSON + natural language. Vision extraction is a separate utility function, not the main path.
+
+## 4. Options Structures Supported
+
+The analyzer should reason about these structures, ranked by complexity:
+
+### MVP (M2-M3)
+1. **Long straddle** — buy ATM call + put. Bet on large move, direction agnostic.
+2. **Long strangle** — buy OTM call + put. Cheaper than straddle, needs bigger move.
+3. **Short iron condor** — sell OTM strangle, buy further OTM for protection. Bet on small move / IV crush.
+4. **Vertical spread** (call or put) — directional bet with defined risk. Used when ktrdr has a signal.
+
+### Full (M5)
+5. **Calendar spread** — sell near-term, buy next-term. Exploit IV crush differential.
+6. **Butterfly** — precision bet on landing zone.
+7. **Custom** — Opus reasons about non-standard structures when the setup warrants it.
+
+## 5. Key Computations
+
+### 5.1 Historical Earnings Move
+
+For each past earnings event:
+- `actual_move = abs(close_after - close_before) / close_before`
+- `direction = sign(close_after - close_before)`
+- Compute: mean, median, max, min, stdev of actual moves
+- Compute: directional bias (% up vs down)
+
+### 5.2 Implied Move (from current options pricing)
+
+- `implied_move = straddle_price / stock_price` (ATM straddle approximation)
+- More precise: use weekly options expiring right after earnings
+
+### 5.3 IV Rank & IV Percentile
+
+- `IV_rank = (current_IV - 52w_low_IV) / (52w_high_IV - 52w_low_IV)`
+- `IV_percentile = % of days in past year where IV was below current IV`
+- Both range 0-100. High IV rank = options are expensive relative to history.
+
+### 5.4 Edge Estimate
+
+- `edge = historical_avg_move - implied_move` (for long vol plays)
+- If edge > 0: market is underpricing the move → long straddle/strangle
+- If edge < 0: market is overpricing → short premium (iron condor)
+- Adjusted for directional signal from ktrdr
+
+### 5.5 Kelly Criterion Sizing
+
+- `kelly_fraction = (p * b - q) / b`
+  - p = probability of winning (from historical win rate at this edge level)
+  - b = payout ratio (risk/reward of the structure)
+  - q = 1 - p
+- Apply half-Kelly as default (standard conservative adjustment)
+- Cap at configurable max risk per trade (default: 2% of account)
+
+**[DECISION POINT]**: Default to half-Kelly, capped at 2% of account value. Karl can override both.
+
+## 6. Use Cases — Detailed
+
+### UC1: Pre-Earnings Analysis
+
+**Trigger**: `epa analyze AAPL` (CLI) or "Analyze AAPL earnings" (conversational)
+
+**Inputs**: Ticker, optional risk budget, optional ktrdr signal override
+
+**Process**:
+1. Fetch next earnings date for AAPL
+2. Fetch historical earnings moves (past 8-20 quarters)
+3. Fetch current options chain for nearest post-earnings expiry
+4. Compute IV rank, implied move, historical move stats
+5. Compute edge estimate
+6. If ktrdr signal available, incorporate directional view
+7. Select candidate structures based on edge direction + magnitude
+8. Compute Kelly sizing for top candidates
+9. Send structured data to Opus 4.7 for reasoning + final recommendation
+10. Output recommendation
+
+**Output**:
+```
+AAPL Earnings Analysis — 2026-04-24 (AMC)
+═══════════════════════════════════════════
+Historical moves (12Q): avg 4.2%, med 3.8%, max 8.1%
+Implied move: 5.1% (market pricing > historical avg)
+IV Rank: 72 | IV Percentile: 81
+Edge: -0.9% (market overpricing move)
+
+ktrdr signal: BUY (confidence: 0.73)
+
+Recommendation: BULL PUT SPREAD
+  Sell AAPL 195P / Buy AAPL 190P — Apr 25 expiry
+  Credit: $1.85 | Max risk: $3.15 | R:R = 1:1.7
+
+Sizing: 3 contracts (1.4% of $65,000 account)
+  Kelly suggests 2.8% → half-Kelly = 1.4%
+
+Rationale: Market is overpricing the move (implied 5.1% vs
+historical 4.2%). IV crush favors short premium. ktrdr BUY
+signal with 0.73 confidence supports directional tilt toward
+bull put spread over neutral iron condor.
+```
+
+### UC2: No ktrdr Signal Available
+
+Same as UC1 but:
+- Skip step 6
+- Structure selection defaults to non-directional (straddle, strangle, or iron condor)
+- Recommendation explicitly notes: "No directional signal available — defaulting to direction-neutral structure"
+
+### UC3: Low IV Rank (Poor Setup)
+
+If IV rank < 30:
+- Flag setup as **unfavorable** for earnings plays
+- Explain: "IV is low relative to history — options are cheap, but that means the market isn't pricing much of a move. Historical earnings moves for this ticker are modest."
+- If edge is still positive: "There may be a small edge in buying premium here, but sizing should be minimal"
+- If edge is negative: "**SKIP RECOMMENDATION** — no edge, low IV, no trade here"
+
+### UC4: Screenshot Input
+
+**Trigger**: User provides screenshot of broker options chain
+
+**Process**:
+1. Send image to Opus 4.7 vision
+2. Extract: strike prices, bid/ask, IV per strike, expiration date, underlying price
+3. Construct structured data object from extracted values
+4. Proceed with analysis as normal (steps 4-10 of UC1)
+
+**Constraints**: Opus 4.7 vision extraction is best-effort. System should ask user to confirm extracted values before proceeding with analysis.
+
+### UC5: Post-Earnings Review
+
+**Trigger**: `epa review AAPL` (after earnings have occurred)
+
+**Process**:
+1. Look up previous prediction for this ticker
+2. Fetch actual post-earnings move
+3. Compare predicted vs actual
+4. Update calibration database
+5. Output performance summary
+
+**Output**:
+```
+AAPL Post-Earnings Review — 2026-04-24
+═══════════════════════════════════════
+Predicted: -0.9% edge (market overpricing)
+Actual move: 3.1% (vs 5.1% implied) ← Market DID overprice
+Trade result: Bull put spread → PROFIT ($555 on $945 risk)
+
+Cumulative accuracy: 7/11 correct edge direction (63.6%)
+Calibration: system slightly overestimates historical move reversion
+```
+
+## 7. Non-Goals
+
+1. **Not a trading bot** — does not auto-execute trades. Produces recommendations; Karl decides.
+2. **Not real-time** — runs on demand, not streaming. No need for WebSocket connections or live tickers.
+3. **Not multi-asset** — equities with listed options only. No futures, no forex, no crypto.
+4. **Not a backtester** — does not simulate portfolio-level P&L over time. Single-event analysis.
+5. **Not a general options analytics platform** — focused exclusively on earnings plays. Does not analyze non-event options strategies.
+6. **Not portfolio-aware** — does not consider existing positions, margin requirements, or correlation with other holdings (future enhancement).
+
+## 8. Interface
+
+**[DECISION POINT]**: CLI for MVP. Reasoning:
+- Karl is a developer; CLI is natural
+- Fastest to build and iterate
+- Easy to call from scripts or notebooks
+- Can be wrapped in Telegram bot or web UI later
+
+**CLI design**:
+```bash
+# Core commands
+epa analyze AAPL                    # Full analysis
+epa analyze AAPL --budget 65000     # With account size
+epa analyze AAPL --signal BUY:0.73  # Manual signal override
+epa analyze AAPL --earnings-date 2026-04-24  # Override earnings date
+epa review AAPL                     # Post-earnings review
+epa calibration                     # Show calibration stats
+epa upcoming                        # List upcoming earnings for watchlist
+epa set-earnings AAPL 2026-04-24 AMC  # Pre-set known earnings date
+
+# Configuration
+epa config set account_size 65000
+epa config set max_risk_pct 2.0
+epa config set kelly_fraction 0.5
+epa watchlist add AAPL MSFT GOOGL AMZN META
+```
+
+## 9. Persistence
+
+**[DECISION POINT]**: SQLite for MVP. Reasoning:
+- Queryable (unlike flat files) — important for calibration history
+- Zero infrastructure (unlike PostgreSQL)
+- Single file, portable, backup-friendly
+- Python stdlib support (`sqlite3`)
+
+**What's stored**:
+- Predictions: ticker, date, predicted edge, recommended structure, sizing
+- Actuals: ticker, date, actual move, trade P&L
+- Calibration: running accuracy stats, systematic biases
+- Configuration: account size, risk parameters, watchlist
+- IV history: cached IV time series for IV rank computation
+
+**Schema**: defined in ARCHITECTURE.md
+
+## 10. MVP Definition
+
+**MVP = M1 + M2 + M3** (Data Foundation + Analysis Engine + Opus Reasoning)
+
+MVP delivers: `epa analyze AAPL` → structured recommendation with rationale
+
+MVP does NOT require:
+- IBKR connection (uses yfinance only)
+- ktrdr signal (optional, file-based if available)
+- Trade execution
+- Telegram/web interface
+
+**Success criteria for MVP**: Karl can run it before an earnings event, get a recommendation he considers reasonable, and decide whether to trade based on it.
+
+## 11. Open Questions for Karl
+
+1. **Watchlist scope**: How many tickers will you typically analyze? (10? 50? 500?) Affects data caching strategy.
+2. **Signal format**: Is the ktrdr signal output format fixed? Where does it write? What's the schema?
+3. **Account sizing**: Do you want to input account size per-run or configure once? Multiple accounts?
+4. **Earnings data quality**: Have you validated yfinance earnings dates against your actual trading? Any known gaps?
+5. **Risk appetite**: Is 2% max risk per trade right, or do you size differently for earnings?
+6. **Deployment**: Mac laptop only, or also want to run on Azure ACA? Affects persistence choices.

--- a/docs/designs/earnings-play-analyzer/REVIEW.md
+++ b/docs/designs/earnings-play-analyzer/REVIEW.md
@@ -1,0 +1,102 @@
+# Earnings Play Analyzer — Design Review
+
+**Reviewer**: Fintech Design Squad Reviewer
+**Date**: 2026-04-18
+**Documents reviewed**: DESIGN.md, ARCHITECTURE.md
+
+---
+
+## Verdict: PROCEED (with corrections applied below)
+
+The design is solid and comprehensive. The following issues were identified, categorized, and corrections have been incorporated into updated DESIGN.md and ARCHITECTURE.md.
+
+---
+
+## Review Checklist
+
+### 1. Completeness
+
+| Area | Status | Notes |
+|------|--------|-------|
+| All integration points defined | PASS | yfinance, IBKR, ktrdr, Anthropic API all specified |
+| Error paths | PASS | Error handling table is thorough |
+| Non-goals | PASS | Well-defined, prevents scope creep |
+| Data models | PASS | All dataclasses are complete |
+| CLI interface | PASS | Command structure is clear |
+| Persistence schema | PASS | SQLite schema covers all use cases |
+| Fallback behavior | PASS | Rule-based fallback when Opus unavailable |
+
+### 2. Feasibility
+
+| Concern | Assessment |
+|---------|------------|
+| yfinance earnings dates | **MINOR ISSUE** — `ticker.earnings_dates` is available but can be unreliable for future dates. The property sometimes returns historical analyst estimates, not confirmed dates. **Mitigation**: Cross-reference with `ticker.calendar` and allow manual date override via CLI (`--earnings-date`). Applied to DESIGN.md. |
+| yfinance IV data | **MINOR ISSUE** — yfinance does not provide a direct "IV" time series for computing IV rank. Individual option IVs are available per strike, but historical ATM IV must be approximated from options chain snapshots over time. **Mitigation**: Compute IV from ATM options on each data fetch, cache in SQLite, build up history over time. First run will have limited IV rank accuracy. Document this bootstrap period. Applied to ARCHITECTURE.md. |
+| yfinance options chain completeness | **OK** — `ticker.option_chain(expiry)` returns adequate data for MVP. Greeks may be computed server-side by Yahoo, not always present. **Mitigation**: Compute Greeks locally from Black-Scholes if missing (add to analysis engine). |
+| Opus 4.7 vision extraction | **OK** — Vision capabilities are strong enough for options chain screenshots. Structured extraction prompts work well. The confirm-before-proceeding UX is the right call. |
+| ktrdr file-based integration | **OK** — Simple, decoupled. The 24h staleness window is appropriate for earnings setups. |
+| Click CLI | **OK** — Standard, well-supported. |
+
+### 3. Domain Correctness
+
+| Concept | Assessment |
+|---------|------------|
+| IV Rank formula | **CORRECT** — `(current - 52w_low) / (52w_high - 52w_low)` is the standard definition. |
+| IV Percentile | **CORRECT** — Percentile rank over trailing year. |
+| Implied move from straddle | **CORRECT** — ATM straddle price / underlying price is the standard approximation. More precise: use the weekly expiry straddling the earnings date. Design correctly notes this. |
+| Kelly criterion | **CORRECT** — `(p*b - q) / b` is standard. Half-Kelly is the industry-standard conservative adjustment. |
+| IV crush mechanics | **MINOR GAP** — Design mentions IV crush but doesn't explicitly model it. For short premium plays (iron condor), the expected P&L depends heavily on post-earnings IV drop, not just move size. **Correction**: Added IV crush estimation to the analysis engine — estimate post-earnings IV as the lower of (a) pre-event IV * 0.5 or (b) IV at same tenor one week prior to earnings run-up. This improves short premium structure scoring. |
+| Options structure scoring | **MINOR GAP** — The structure selector should weight by expected P&L, not just edge direction. A long straddle with 3% edge but high break-even spread may be worse than a strangle with 2% edge but cheaper entry. **Correction**: StructureSelector now scores by `expected_value = prob_profit * avg_profit - prob_loss * avg_loss`, using historical move distribution. |
+| Earnings time (BMO/AMC) | **CORRECT** — Correctly tracked. Important because BMO earnings use the prior day's close as reference, AMC uses same day. Design handles this. |
+
+### 4. Architecture Quality
+
+| Area | Assessment |
+|------|------------|
+| Data ownership | **GOOD** — Clear separation. Data layer owns acquisition, analysis engine owns computation, reasoner owns narrative. No overlapping responsibilities. |
+| Failure modes | **GOOD** — Each component can fail independently. Orchestrator handles graceful degradation. |
+| Testability | **GOOD** — Analysis engine is pure computation with no external dependencies. Easy to test with synthetic data. Fixtures directory is a good call. |
+| State management | **GOOD** — SQLite is the single source of truth. No in-memory state that needs synchronization. |
+| Provider abstraction | **GOOD** — Protocol-based DataProvider allows swapping yfinance → IBKR without changing upstream code. |
+| Prompt design | **ADEQUATE** — Prompt structure is described but actual prompt templates aren't fully specified. This is acceptable for design phase — prompts will be iterated during M3. |
+
+### 5. Gaps Identified and Addressed
+
+#### Gap 1: IV History Bootstrap Problem
+**Issue**: IV rank requires 252 trading days of IV history. On first run, this doesn't exist.
+**Resolution**: Added bootstrap strategy — on first run, compute approximate IV rank from VIX percentile (for S&P 500 components) or skip IV rank and note "insufficient IV history" in output. After ~2 weeks of daily caching, IV rank becomes usable. Added to ARCHITECTURE.md notes.
+
+#### Gap 2: Earnings Date Override
+**Issue**: yfinance earnings dates can be wrong or missing.
+**Resolution**: Added `--earnings-date` CLI flag for manual override. Also added `epa set-earnings AAPL 2026-04-24 AMC` command for pre-setting known dates. Applied to DESIGN.md CLI section.
+
+#### Gap 3: Rate Limiting / Data Caching
+**Issue**: yfinance has undocumented rate limits. Analyzing 10 tickers in sequence might get throttled.
+**Resolution**: Added caching layer — options snapshots cached for 15 minutes, earnings history cached for 24 hours, IV data cached for 1 hour. Cache stored in SQLite `iv_cache` table (already in schema) + new `data_cache` table. Applied to ARCHITECTURE.md.
+
+#### Gap 4: Expected Value Scoring for Structures
+**Issue**: Original design scored structures by directional fit only, not expected P&L.
+**Resolution**: StructureSelector now computes expected value using historical move distribution to estimate probability of profit for each structure. Applied to ARCHITECTURE.md analysis section.
+
+---
+
+## Summary of Changes Applied
+
+1. **DESIGN.md**: Added `--earnings-date` override to CLI, noted IV history bootstrap limitation
+2. **ARCHITECTURE.md**: Added IV crush estimation to analysis engine, added data caching layer, added Greeks computation fallback, refined structure scoring methodology, added `data_cache` table to schema
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| yfinance API changes/breaks | Medium | High | Provider abstraction allows quick swap to alternative |
+| Opus API costs for frequent analysis | Low | Medium | Configurable — can run rule-based only for quick checks |
+| Kelly sizing suggests too-large positions | Low | High | Hard cap at max_risk_pct, half-Kelly default |
+| IV rank inaccurate in early usage | High (first 2 weeks) | Medium | Bootstrap strategy + clear warnings in output |
+| ktrdr signal format changes | Low | Low | Adapter pattern isolates changes |
+
+## Final Assessment
+
+The design is well-structured, domain-correct, and implementable. The identified gaps are minor and have been addressed. The milestone progression (data → analysis → reasoning → ktrdr → IBKR) is logical and each milestone delivers testable value. Ready for implementation planning.
+
+**Verdict: PROCEED**

--- a/docs/designs/earnings-play-analyzer/implementation/M1_data_foundation.md
+++ b/docs/designs/earnings-play-analyzer/implementation/M1_data_foundation.md
@@ -1,0 +1,177 @@
+# M1: Data Foundation
+
+**Goal**: Fetch historical earnings data and current IV stats for a ticker, display raw numbers via CLI. Proves the data pipeline works end-to-end.
+
+**Success criteria**: `epa analyze AAPL` outputs a formatted table of historical earnings moves + current IV data, sourced from yfinance, with data cached in SQLite.
+
+---
+
+## Task 1.1: Project Scaffolding
+
+**Files to create**:
+- `pyproject.toml` — project metadata, dependencies (click, rich, yfinance, anthropic, pytest, ruff)
+- `epa/__init__.py` — version string
+- `epa/__main__.py` — `from epa.cli import cli; cli()`
+- `epa/cli.py` — Click group with stub `analyze` command
+- `epa/config.py` — Config loader (reads `~/.epa/config.toml`, env vars, CLI args)
+
+**Behavior**:
+- `pip install -e .` works
+- `epa` prints help
+- `epa analyze AAPL` prints "Not yet implemented" (placeholder)
+- Config loads `ANTHROPIC_API_KEY` from env, other settings from TOML with defaults
+
+**Tests**:
+- `test_cli.py`: CLI group exists, help renders, analyze command accepts ticker arg
+- `test_config.py`: Config loads defaults when no file exists, respects env vars
+
+---
+
+## Task 1.2: Data Models
+
+**Files to create**:
+- `epa/data/__init__.py`
+- `epa/data/models.py` — all dataclasses: `EarningsEvent`, `EarningsHistory`, `OptionsSnapshot`, `OptionQuote`, `IVData`
+
+**Behavior**:
+- All models are frozen dataclasses with type hints
+- Models have `to_dict()` / `from_dict()` methods for JSON serialization
+- `EarningsHistory` computes summary stats (avg, median, stdev) from events list
+
+**Tests**:
+- `test_models.py`: Construct each model, verify serialization roundtrip, verify computed stats
+
+---
+
+## Task 1.3: SQLite Store
+
+**Files to create**:
+- `epa/store/__init__.py`
+- `epa/store/db.py` — `EpaStore` class with schema init, prediction CRUD, config CRUD, watchlist, caching
+
+**Behavior**:
+- Creates `~/.epa/epa.db` on first use (directory auto-created)
+- Schema migration: version table tracks schema version, applies migrations sequentially
+- All methods handle SQLite errors gracefully (log + continue for non-critical ops)
+- Data cache: `get_cached(key, ttl_seconds)` / `set_cached(key, data_json, ttl_seconds)`
+
+**Tests**:
+- `test_db.py`: Using in-memory SQLite (`:memory:`), test: save/load prediction, config CRUD, watchlist add/remove/list, cache set/get/expiry
+
+---
+
+## Task 1.4: yfinance Provider — Earnings History
+
+**Files to create**:
+- `epa/data/providers/__init__.py`
+- `epa/data/providers/yfinance_provider.py` — `YFinanceProvider` class
+
+**Behavior (this task: earnings history only)**:
+- `get_earnings_history(ticker, quarters=16)` → `EarningsHistory`
+- Fetches earnings dates from yfinance
+- For each earnings date, fetches close price before and after
+- Computes actual move percentage and direction
+- Handles BMO vs AMC (BMO: compare prior close to same-day close; AMC: compare same-day close to next-day open/close)
+- Returns `EarningsHistory` with computed summary stats
+- Caches result in SQLite data_cache (TTL: 24 hours)
+
+**Tests**:
+- `test_yfinance_provider.py`: Mock yfinance responses with fixture data. Test: correct move calculation for BMO and AMC events, handles missing data, cache hit avoids re-fetch.
+
+**Fixture files**:
+- `epa/tests/fixtures/aapl_earnings_dates.json`
+- `epa/tests/fixtures/aapl_price_history.json`
+
+---
+
+## Task 1.5: yfinance Provider — Options & IV Data
+
+**Files to modify**:
+- `epa/data/providers/yfinance_provider.py` — add `get_options_snapshot()`, `get_iv_data()`, `get_next_earnings_date()`
+
+**Behavior**:
+- `get_options_snapshot(ticker, target_expiry)` → `OptionsSnapshot`
+  - Fetches options chain for nearest expiry on/after target date
+  - Parses calls and puts into `OptionQuote` objects
+  - Computes ATM straddle price and implied move
+  - If Greeks are missing from yfinance, computes delta from Black-Scholes (utility function)
+  - Cache TTL: 15 minutes
+
+- `get_iv_data(ticker)` → `IVData`
+  - Computes current ATM IV from options chain
+  - Loads IV history from SQLite cache
+  - If history < 30 days: flags as bootstrapping, uses VIX percentile for S&P 500 tickers
+  - Computes IV rank and IV percentile from available history
+  - Saves current IV to cache for future rank calculations
+
+- `get_next_earnings_date(ticker)` → `EarningsEvent | None`
+  - Returns next upcoming earnings date, or None if not found
+  - Supports manual override from store config
+
+**Tests**:
+- `test_yfinance_options.py`: Mock yfinance option chain responses. Test: correct ATM straddle computation, implied move calculation, IV rank with full history, IV rank bootstrap behavior.
+
+**Fixture files**:
+- `epa/tests/fixtures/aapl_options_chain.json`
+
+---
+
+## Task 1.6: CLI Analyze (Raw Output)
+
+**Files to modify**:
+- `epa/cli.py` — implement `analyze` command with raw data output
+- `epa/orchestrator.py` (new) — `Orchestrator` class that coordinates data fetching
+
+**Behavior**:
+- `epa analyze AAPL` fetches all data and prints formatted output:
+  ```
+  AAPL — Next earnings: 2026-04-24 (AMC)
+  
+  Historical Earnings Moves (12 quarters)
+  ┌──────────┬───────┬───────────┐
+  │ Date     │ Move  │ Direction │
+  ├──────────┼───────┼───────────┤
+  │ 2026-01  │ 3.2%  │ ▲ UP      │
+  │ 2025-10  │ 5.1%  │ ▼ DOWN    │
+  │ ...      │       │           │
+  └──────────┴───────┴───────────┘
+  Avg: 4.2% | Med: 3.8% | Max: 8.1% | StdDev: 1.9%
+  Direction bias: 58% UP
+  
+  Current IV Data
+  IV Rank: 72 | IV Percentile: 81
+  Implied Move: 5.1%
+  ATM Straddle: $9.85 (195 strike)
+  ```
+- `--json` flag outputs raw JSON instead
+- `--earnings-date` overrides the detected earnings date
+- `--budget` stores account size in config for later use
+
+**Tests**:
+- `test_orchestrator.py`: With mocked provider, verify orchestrator calls all data methods and assembles output correctly.
+
+---
+
+## Task 1.7: M1 Validation
+
+**Goal**: End-to-end test with real yfinance data (integration test, marked slow).
+
+**Files to create**:
+- `epa/tests/test_m1_e2e.py`
+
+**Test cases**:
+1. `epa analyze AAPL` with live yfinance data — produces output without errors
+2. Second run of same ticker — data served from cache (verify no yfinance call)
+3. `epa analyze INVALIDTICKER` — graceful error message
+4. `epa analyze AAPL --json` — outputs valid JSON
+5. Verify SQLite database created at expected path with expected tables
+
+**Validation script** (manual):
+```bash
+pip install -e .
+epa analyze AAPL
+epa analyze MSFT --json
+epa analyze AAPL  # should be fast (cached)
+```
+
+**Done when**: Karl can run `epa analyze <ticker>` for any optionable stock and see accurate historical earnings data + current IV stats.

--- a/docs/designs/earnings-play-analyzer/implementation/M2_analysis_engine.md
+++ b/docs/designs/earnings-play-analyzer/implementation/M2_analysis_engine.md
@@ -1,0 +1,182 @@
+# M2: Analysis Engine
+
+**Goal**: Given fetched data, compute earnings edge estimate, select candidate options structures, apply Kelly sizing, and output a structured recommendation object. No LLM involved — pure computation.
+
+**Success criteria**: `epa analyze AAPL --budget 65000` outputs a rule-based recommendation with edge estimate, recommended structure, and position size.
+
+**Depends on**: M1 (data models, provider, store, CLI)
+
+---
+
+## Task 2.1: Edge Calculator
+
+**Files to create**:
+- `epa/analysis/__init__.py`
+- `epa/analysis/edge.py` — `EdgeCalculator` class
+
+**Behavior**:
+- `compute_edge(history, snapshot)` → `EdgeEstimate`
+  - `edge_pct = history.avg_move - snapshot.implied_move_pct`
+  - `direction = "long_vol"` if edge > 0, `"short_vol"` if edge < 0
+  - `confidence` based on: sample size (more quarters = higher), consistency of moves (lower stdev = higher), magnitude of edge (larger = higher)
+  - Confidence formula: `min(1.0, (n_quarters / 12) * (1 - stdev/avg_move) * min(abs(edge) / 2.0, 1.0))`
+- `estimate_iv_crush(iv_data, snapshot)` → `float`
+  - Estimates post-earnings IV drop
+  - `post_iv = min(current_iv * 0.5, pre_runup_iv_estimate)`
+  - `iv_crush = current_iv - post_iv`
+  - Used by structure scorer for short premium strategies
+- Generates human-readable rationale string
+
+**Tests**:
+- `test_edge.py`:
+  - Positive edge: historical avg > implied → long_vol direction
+  - Negative edge: historical avg < implied → short_vol direction
+  - Zero edge: edge ~0 → low confidence
+  - High consistency (low stdev) → higher confidence
+  - Small sample (4 quarters) → lower confidence
+  - IV crush estimation with various IV levels
+
+---
+
+## Task 2.2: Structure Selector
+
+**Files to create**:
+- `epa/analysis/structures.py` — `StructureSelector` class, `OptionsStructure` and `OptionLeg` dataclasses
+
+**Behavior**:
+- `select_candidates(edge, snapshot, history, signal=None)` → `list[OptionsStructure]`
+- Builds candidate structures from the options chain:
+  - **Long straddle**: ATM call + ATM put. Suitable when edge > 0, no directional view.
+  - **Long strangle**: OTM call + OTM put (1 strike out from ATM). Cheaper, needs bigger move.
+  - **Iron condor**: Sell OTM strangle, buy further OTM wings. Suitable when edge < 0.
+  - **Bull call spread / bull put spread**: When signal = BUY. Uses ATM/OTM strikes.
+  - **Bear put spread / bear call spread**: When signal = SELL.
+- For each structure, computes:
+  - `max_profit`, `max_loss` from strike widths and premiums
+  - `breakeven` points
+  - `score` = expected value using historical move distribution:
+    - Simulate each historical move against the structure's P&L profile
+    - `EV = mean(simulated P&L across historical moves)`
+    - Normalize to 0-1 score
+- Sorts candidates by score descending
+- Filters out structures with negative EV (unless all are negative → return best with warning)
+
+**Tests**:
+- `test_structures.py`:
+  - Long vol edge + no signal → straddle/strangle ranked highest
+  - Short vol edge + no signal → iron condor ranked highest
+  - BUY signal + positive edge → bull spread ranked high
+  - SELL signal + negative edge → bear spread ranked high
+  - Verify breakeven calculations for each structure type
+  - Verify max_profit and max_loss calculations
+
+---
+
+## Task 2.3: Kelly Criterion Sizing
+
+**Files to create**:
+- `epa/analysis/sizing.py` — `KellySizer` class, `SizingResult` dataclass
+
+**Behavior**:
+- `compute_size(edge, structure, account_size, max_risk_pct=2.0, kelly_fraction=0.5)` → `SizingResult`
+- Estimates win probability from edge confidence and historical win rate at similar edge levels
+- `kelly_raw = (p * b - q) / b` where:
+  - `p` = estimated win probability
+  - `b` = structure.max_profit / structure.max_loss (reward/risk ratio)
+  - `q` = 1 - p
+- `kelly_applied = kelly_raw * kelly_fraction` (default half-Kelly)
+- `capital_at_risk = account_size * min(kelly_applied, max_risk_pct / 100)`
+- `contracts = floor(capital_at_risk / structure.max_loss)` (at least 1 if capital allows)
+- If `kelly_raw <= 0`: no edge → recommend SKIP, contracts = 0
+- Generates rationale explaining the sizing
+
+**Tests**:
+- `test_sizing.py`:
+  - Positive edge → positive Kelly → non-zero contracts
+  - Large edge → more contracts (up to cap)
+  - Kelly exceeds max_risk_pct → capped
+  - Negative Kelly → 0 contracts, SKIP recommendation
+  - Half-Kelly vs full-Kelly gives different sizes
+  - Account too small for even 1 contract → 0 contracts with warning
+
+---
+
+## Task 2.4: Rule-Based Recommendation Builder
+
+**Files to create**:
+- `epa/analysis/recommender.py` — `RuleBasedRecommender` class
+
+**Behavior**:
+- `recommend(history, iv_data, snapshot, edge, candidates, sizing, signal=None)` → `TradeRecommendation`
+- Decision logic:
+  1. If `edge.confidence < 0.2` → action = "SKIP", rationale = "insufficient confidence"
+  2. If `iv_data.iv_rank < 30` and `edge.direction == "long_vol"` → action = "SKIP", rationale = "low IV rank, poor setup for buying premium"
+  3. If `sizing.contracts == 0` → action = "SKIP", rationale = "Kelly sizing suggests no edge"
+  4. Otherwise → action = "TRADE", pick top-scored structure, apply sizing
+- Generates template-based rationale explaining the decision
+- Compiles all input data into `raw_data` field for audit
+
+**Tests**:
+- `test_recommender.py`:
+  - Strong positive edge → TRADE with long vol structure
+  - Strong negative edge → TRADE with short vol structure
+  - Low confidence → SKIP
+  - Low IV rank + long vol → SKIP
+  - No edge (Kelly <= 0) → SKIP
+
+---
+
+## Task 2.5: CLI Integration
+
+**Files to modify**:
+- `epa/orchestrator.py` — add analysis pipeline after data fetching
+- `epa/cli.py` — update output formatting for full recommendation
+
+**Behavior**:
+- `epa analyze AAPL --budget 65000` now outputs:
+  ```
+  AAPL Earnings Analysis — 2026-04-24 (AMC)
+  ═══════════════════════════════════════════
+  Historical moves (12Q): avg 4.2%, med 3.8%, max 8.1%
+  Implied move: 5.1%
+  IV Rank: 72 | IV Percentile: 81
+  Edge: -0.9% (short_vol, confidence: 0.65)
+
+  Recommendation: TRADE — SHORT IRON CONDOR
+    Sell AAPL 200C/190P, Buy AAPL 205C/185P — Apr 25 expiry
+    Max profit: $2.40 | Max loss: $2.60 | R:R = 1:1.08
+
+  Sizing: 5 contracts ($1,300 risk, 2.0% of $65,000)
+    Kelly raw: 4.1% → half-Kelly: 2.05% → capped at 2.0%
+
+  [Rule-based recommendation — Opus reasoning not enabled]
+  ```
+- Saves prediction to SQLite store
+- `--json` outputs structured JSON
+
+**Tests**:
+- `test_orchestrator.py`: End-to-end with mocked provider, verify full pipeline produces recommendation
+
+---
+
+## Task 2.6: M2 Validation
+
+**Files to create**:
+- `epa/tests/test_m2_e2e.py`
+
+**Test cases**:
+1. Full pipeline with fixture data covering each recommendation path (TRADE/SKIP)
+2. Edge cases: ticker with only 4 quarters of history, ticker with no options chain
+3. Verify prediction saved to SQLite after analysis
+4. Verify `--json` output matches `TradeRecommendation` schema
+5. Multiple structure types correctly scored and ranked
+
+**Validation script** (manual):
+```bash
+epa analyze AAPL --budget 65000
+epa analyze TSLA --budget 65000          # typically high IV, volatile
+epa analyze KO --budget 65000            # typically low IV, small moves
+epa analyze AAPL --budget 65000 --json   # verify JSON schema
+```
+
+**Done when**: The system produces reasonable, sized trade recommendations for various tickers based purely on data and rules, without any LLM involvement.

--- a/docs/designs/earnings-play-analyzer/implementation/M3_opus_reasoning.md
+++ b/docs/designs/earnings-play-analyzer/implementation/M3_opus_reasoning.md
@@ -1,0 +1,159 @@
+# M3: Opus Reasoning
+
+**Goal**: Wire Opus 4.7 to reason over the structured analysis, producing natural language rationale and a refined final recommendation. Full E2E: ticker in → recommendation with reasoning out.
+
+**Success criteria**: `epa analyze AAPL` produces an Opus-generated recommendation that cites specific data points, explains the structure choice, and identifies risk factors.
+
+**Depends on**: M2 (analysis engine, edge, structures, sizing)
+
+---
+
+## Task 3.1: Opus Reasoner Core
+
+**Files to create**:
+- `epa/reasoner/__init__.py`
+- `epa/reasoner/opus.py` — `OpusReasoner` class
+- `epa/reasoner/prompts.py` — prompt templates
+
+**Behavior**:
+- `OpusReasoner.__init__(api_key, model="claude-opus-4-6")`
+  - Initializes Anthropic client
+  - Model configurable via `~/.epa/config.toml`
+
+- `reason_about_trade(history, iv_data, edge, candidates, sizing, signal=None)` → `TradeRecommendation`
+  - Constructs prompt with:
+    - System prompt: role definition (experienced options trader), output format spec (JSON + rationale)
+    - User message: all structured data as JSON
+  - Sends to Opus with `max_tokens=4096`
+  - Parses response: expects JSON block with `action`, `structure_name`, `rationale`, `confidence`, `risk_factors`
+  - Opus may override the rule-based recommendation if it identifies issues the rules miss
+  - Uses prompt caching: system prompt is stable across calls, only user data changes
+
+- Error handling:
+  - API timeout/error → retry 2x with backoff
+  - After retries fail → fall back to rule-based recommendation from M2
+  - Parse error → log raw response, fall back to rule-based
+
+**Prompt design** (in `prompts.py`):
+```
+SYSTEM: You are an experienced options trader specializing in earnings plays.
+You are given structured data about a ticker's earnings setup and candidate
+trade structures. Your job is to:
+1. Validate the edge estimate — does the data support it?
+2. Select the best structure (or reject all candidates)
+3. Confirm or adjust the sizing
+4. Provide a clear, concise rationale citing specific numbers
+5. Identify 2-3 key risk factors
+
+Output JSON: { action, structure_name, sizing_adjustment, rationale, confidence, risk_factors }
+```
+
+**Tests**:
+- `test_opus.py`:
+  - Mock Anthropic client — verify prompt construction includes all data
+  - Verify response parsing for valid JSON response
+  - Verify fallback on API error
+  - Verify fallback on malformed response
+  - Verify prompt caching headers sent
+
+---
+
+## Task 3.2: Vision Extraction
+
+**Files to create**:
+- `epa/data/providers/vision_provider.py` — `VisionProvider` class
+
+**Behavior**:
+- `extract_options_chain(image_path)` → `OptionsSnapshot`
+  - Sends image to Opus 4.7 vision with extraction prompt
+  - Prompt asks for: underlying price, expiry date, list of (strike, call_bid, call_ask, call_iv, put_bid, put_ask, put_iv)
+  - Parses structured response into `OptionsSnapshot`
+  - Returns extracted data with confidence flag
+
+- CLI integration: `epa analyze AAPL --screenshot /path/to/chain.png`
+  - Extracts data from screenshot
+  - Prints extracted values and asks for confirmation (interactive)
+  - Proceeds with analysis using extracted data
+
+**Tests**:
+- `test_vision.py`:
+  - Mock Opus response with sample extraction
+  - Verify parsing into `OptionsSnapshot`
+  - Test with malformed response → graceful error
+
+---
+
+## Task 3.3: Post-Earnings Review
+
+**Files to modify**:
+- `epa/orchestrator.py` — add `review` workflow
+- `epa/cli.py` — implement `review` command
+- `epa/store/db.py` — add `save_actual()`, `get_calibration_stats()`
+
+**Behavior**:
+- `epa review AAPL`
+  1. Look up most recent prediction for AAPL in store
+  2. Fetch actual post-earnings price move from yfinance
+  3. Compare: predicted edge direction vs actual move vs implied move
+  4. Compute: was the edge call correct? (predicted overpricing → actual move < implied?)
+  5. Save actual result to store
+  6. Display comparison
+
+- `epa calibration`
+  1. Query all prediction/actual pairs
+  2. Compute: hit rate (% correct edge direction), average edge estimation error, systematic biases
+  3. Display summary table
+
+**Tests**:
+- `test_review.py`:
+  - Prediction exists + actual available → correct comparison
+  - No prediction found → helpful error
+  - Earnings not yet occurred → "earnings haven't happened yet"
+  - Calibration stats with mix of correct/incorrect predictions
+
+---
+
+## Task 3.4: Orchestrator E2E Integration
+
+**Files to modify**:
+- `epa/orchestrator.py` — wire Opus reasoner into analyze pipeline
+
+**Behavior**:
+- Full pipeline: data → analysis → Opus reasoning → output
+- Opus is called after rule-based recommendation is computed
+- If Opus and rules agree → high confidence output
+- If Opus disagrees with rules → Opus recommendation takes priority, but the disagreement is noted
+- If `config.opus.enabled = false` → skip Opus, use rule-based only
+- Output clearly indicates whether Opus or rules produced the recommendation
+
+**Tests**:
+- `test_orchestrator_e2e.py`:
+  - Full pipeline with mocked provider + mocked Opus → verify all components called in order
+  - Opus disabled → rule-based output produced
+  - Opus error → graceful fallback to rule-based
+
+---
+
+## Task 3.5: M3 Validation
+
+**Files to create**:
+- `epa/tests/test_m3_e2e.py`
+
+**Test cases** (integration, requires ANTHROPIC_API_KEY):
+1. `epa analyze AAPL --budget 65000` → Opus-generated recommendation with rationale
+2. Verify rationale cites specific numbers from the input data
+3. Verify `epa review AAPL` works after a prediction exists
+4. Verify `epa calibration` produces stats
+5. `epa analyze AAPL --json` → valid JSON with Opus rationale embedded
+
+**Validation script** (manual):
+```bash
+export ANTHROPIC_API_KEY=sk-...
+epa analyze AAPL --budget 65000          # Full Opus recommendation
+epa analyze TSLA --budget 65000          # Different setup
+epa review AAPL                          # If earnings already passed
+epa calibration                          # Should show stats
+epa analyze AAPL --screenshot chain.png  # Vision extraction
+```
+
+**Done when**: Full E2E works — ticker in, Opus-reasoned recommendation out. Karl can use this before an earnings event to get a well-reasoned trade recommendation.

--- a/docs/designs/earnings-play-analyzer/implementation/M4_ktrdr_integration.md
+++ b/docs/designs/earnings-play-analyzer/implementation/M4_ktrdr_integration.md
@@ -1,0 +1,121 @@
+# M4: ktrdr Integration
+
+**Goal**: Add ktrdr ML directional signal as an optional input. When a signal is available, structure recommendation adapts to favor directional strategies.
+
+**Success criteria**: `epa analyze AAPL` detects and uses a ktrdr signal file to shift recommendations toward directional structures (bull/bear spreads) instead of neutral ones (straddles/iron condors).
+
+**Depends on**: M2 (structure selector), M3 (Opus reasoner prompt includes signal)
+
+---
+
+## Task 4.1: ktrdr Signal Adapter
+
+**Files to create**:
+- `epa/integrations/__init__.py`
+- `epa/integrations/ktrdr.py` — `KtrdrAdapter` class, `KtrdrSignal` dataclass
+
+**Behavior**:
+- `KtrdrAdapter(signal_dir="~/.ktrdr/signals/")`
+- `get_signal(ticker)` → `KtrdrSignal | None`
+  - Reads `{signal_dir}/{TICKER}.json`
+  - Expected format: `{ "signal": "BUY", "confidence": 0.73, "timestamp": "2026-04-18T14:30:00Z", "model_version": "v2.1" }`
+  - Returns `None` if: file doesn't exist, file is malformed, signal is stale (>24h old)
+  - Staleness threshold configurable via config
+- `is_available()` → `bool` — checks if signal directory exists
+
+**Tests**:
+- `test_ktrdr.py`:
+  - Valid signal file → parsed correctly
+  - Missing file → None
+  - Stale signal (>24h) → None
+  - Malformed JSON → None with logged warning
+  - Signal directory doesn't exist → is_available() = False
+
+**Fixture files**:
+- `epa/tests/fixtures/sample_signal.json`
+
+---
+
+## Task 4.2: Structure Selector Directional Logic
+
+**Files to modify**:
+- `epa/analysis/structures.py` — enhance `select_candidates()` with signal-aware scoring
+
+**Behavior changes**:
+- When `signal` is provided:
+  - BUY signal: boost score of bull call spread and bull put spread by `signal.confidence * 0.3`
+  - SELL signal: boost score of bear put spread and bear call spread by `signal.confidence * 0.3`
+  - HOLD signal: treated same as no signal (neutral structures)
+- When `signal.confidence > 0.8`: add directional vertical spread as a standalone candidate (not just straddle/strangle + directional adjustment)
+- When `signal.confidence < 0.4`: treat as no signal (too weak to act on)
+- Rationale string updated to explain signal influence
+
+**Tests**:
+- `test_structures_directional.py`:
+  - BUY signal with high confidence → bull spread ranks #1
+  - SELL signal with high confidence → bear spread ranks #1
+  - Low confidence signal → same ranking as no signal
+  - HOLD signal → same ranking as no signal
+  - Signal + short_vol edge → careful handling (directional + IV crush is tricky)
+
+---
+
+## Task 4.3: Orchestrator + Opus Prompt Update
+
+**Files to modify**:
+- `epa/orchestrator.py` — add ktrdr adapter call
+- `epa/reasoner/prompts.py` — add signal data section to prompt
+- `epa/cli.py` — add `--signal` manual override, display signal info in output
+
+**Behavior**:
+- Orchestrator checks ktrdr adapter before analysis
+- If signal found: passes to structure selector and Opus reasoner
+- CLI `--signal BUY:0.73` allows manual override (useful when ktrdr not running)
+- Output includes signal section:
+  ```
+  ktrdr Signal: BUY (confidence: 0.73, model: v2.1, age: 2h)
+  ```
+  or:
+  ```
+  ktrdr Signal: unavailable (no signal file found)
+  ```
+
+- Opus prompt updated:
+  - Includes signal data in structured input
+  - Asks Opus to evaluate whether the signal aligns with other indicators
+  - If signal conflicts with edge direction, Opus should flag the tension
+
+**Tests**:
+- `test_orchestrator_ktrdr.py`:
+  - Signal available → passed to analysis and reasoner
+  - Signal unavailable → analysis proceeds without, output notes absence
+  - Manual override via CLI → used instead of file
+  - Signal + conflicting edge → Opus receives both, can reason about conflict
+
+---
+
+## Task 4.4: M4 Validation
+
+**Files to create**:
+- `epa/tests/test_m4_e2e.py`
+
+**Test cases**:
+1. Place a signal file, run analysis → recommendation reflects directional view
+2. Remove signal file, run same analysis → recommendation is neutral
+3. Manual `--signal SELL:0.9` → bear spread recommended
+4. Stale signal file (>24h old) → treated as unavailable
+5. Signal conflicts with edge → output acknowledges tension
+
+**Validation script** (manual):
+```bash
+# Create test signal
+mkdir -p ~/.ktrdr/signals
+echo '{"signal":"BUY","confidence":0.73,"timestamp":"2026-04-18T10:00:00Z","model_version":"v2.1"}' > ~/.ktrdr/signals/AAPL.json
+
+epa analyze AAPL --budget 65000           # Should show BUY signal, may recommend bull spread
+rm ~/.ktrdr/signals/AAPL.json
+epa analyze AAPL --budget 65000           # Should show "signal unavailable"
+epa analyze AAPL --signal SELL:0.9        # Manual override
+```
+
+**Done when**: ktrdr signal is seamlessly integrated — used when available, gracefully absent when not, and its influence on the recommendation is clearly explained in the output.

--- a/docs/designs/earnings-play-analyzer/implementation/M5_ibkr_integration.md
+++ b/docs/designs/earnings-play-analyzer/implementation/M5_ibkr_integration.md
@@ -1,0 +1,173 @@
+# M5: IBKR Integration
+
+**Goal**: Replace yfinance with live IBKR data for real-time options chains and accurate Greeks. Enable paper trade placement for recommended structures.
+
+**Success criteria**: `epa analyze AAPL --provider ibkr` uses live IBKR data, and `epa execute AAPL --paper` places the recommended trade on IBKR paper trading account.
+
+**Depends on**: M1 (data provider interface)
+
+---
+
+## Task 5.1: IBKR Data Provider
+
+**Files to create**:
+- `epa/data/providers/ibkr_provider.py` — `IBKRProvider` class
+
+**Behavior**:
+- Implements the same `DataProvider` protocol as `YFinanceProvider`
+- Connects to TWS/Gateway via `ib_insync` library
+- `get_earnings_history(ticker, quarters)` → fetches from IBKR fundamental data or falls back to yfinance
+- `get_options_snapshot(ticker, target_expiry)` → real-time options chain with accurate Greeks
+  - Uses `ib.reqSecDefOptParams()` for available expirations
+  - Uses `ib.reqMktData()` for live bid/ask/IV/Greeks
+  - Accurate Greeks directly from IBKR (no Black-Scholes approximation needed)
+- `get_iv_data(ticker)` → uses IBKR historical volatility data
+- `get_next_earnings_date(ticker)` → from IBKR corporate events calendar
+
+- Connection management:
+  - Connects on first use, keeps connection alive for session
+  - Handles reconnection on drop
+  - Respects IBKR rate limits (50 messages/second)
+  - Defaults to paper trading port (7497)
+
+**Tests**:
+- `test_ibkr_provider.py`:
+  - Mock `ib_insync.IB` — verify correct API calls made
+  - Verify data mapped correctly to `OptionsSnapshot` model
+  - Connection error handling
+  - Rate limit compliance
+
+**Config**:
+```toml
+[ibkr]
+host = "127.0.0.1"
+port = 7497         # 7497=paper, 7496=live
+client_id = 1
+timeout = 30
+```
+
+---
+
+## Task 5.2: Provider Selection
+
+**Files to modify**:
+- `epa/orchestrator.py` — provider factory based on config
+- `epa/cli.py` — add `--provider` flag
+- `epa/config.py` — add provider selection
+
+**Behavior**:
+- `epa analyze AAPL --provider ibkr` → uses IBKR provider
+- `epa analyze AAPL --provider yfinance` → uses yfinance (default)
+- Config `data.provider` sets default: `"yfinance"` or `"ibkr"`
+- If IBKR selected but TWS not running → clear error: "Cannot connect to TWS/Gateway at 127.0.0.1:7497. Is TWS running?"
+- Hybrid mode: IBKR for live options data, yfinance for historical earnings (IBKR earnings history is less accessible)
+
+**Tests**:
+- `test_provider_selection.py`:
+  - Config says yfinance → yfinance provider created
+  - CLI override → override takes precedence
+  - IBKR selected but unavailable → clear error message
+
+---
+
+## Task 5.3: Paper Trade Execution
+
+**Files to create**:
+- `epa/integrations/ibkr_trader.py` — `IBKRTrader` class
+
+**Behavior**:
+- `execute_recommendation(rec: TradeRecommendation, paper: bool = True)` → `TradeResult`
+  - Builds IBKR order objects from `OptionsStructure` legs
+  - For multi-leg structures: uses combo/bag orders
+  - Submits to paper account (port 7497) by default
+  - `--live` flag required for real money (port 7496) — with explicit confirmation prompt
+  - Returns fill prices, commission, actual position details
+
+- Pre-flight checks before order submission:
+  1. Verify account has sufficient buying power
+  2. Verify option contracts exist and are tradeable
+  3. Verify bid/ask spread is reasonable (warn if > 10% of mid)
+  4. Display order preview and require confirmation
+
+- `TradeResult` dataclass:
+  ```python
+  @dataclass
+  class TradeResult:
+      order_id: int
+      status: str           # "FILLED" | "PARTIAL" | "REJECTED" | "CANCELLED"
+      fill_price: float
+      commission: float
+      legs: list[FilledLeg]
+      timestamp: datetime
+  ```
+
+**Tests**:
+- `test_ibkr_trader.py`:
+  - Mock IB connection — verify order construction for each structure type
+  - Combo order for iron condor (4 legs)
+  - Vertical spread (2 legs)
+  - Pre-flight check failures → order not submitted
+  - Paper vs live port selection
+
+---
+
+## Task 5.4: CLI Execute Command
+
+**Files to modify**:
+- `epa/cli.py` — add `execute` command
+
+**Behavior**:
+- `epa execute AAPL --paper` — execute most recent recommendation for AAPL
+  1. Load most recent prediction from store
+  2. Verify it's still current (earnings hasn't passed, data not stale)
+  3. Display order preview with current live prices
+  4. Require explicit "yes" confirmation
+  5. Submit order
+  6. Display result
+  7. Save trade result to store
+
+- `epa execute AAPL --live` — live trading
+  - Requires TWS connected to live account
+  - Additional confirmation: "WARNING: This will place a LIVE trade. Type 'EXECUTE' to confirm"
+  - Saves to store with `live=True` flag
+
+**Tests**:
+- `test_cli_execute.py`:
+  - No prediction exists → error
+  - Prediction is stale → warning + confirmation
+  - Paper trade flow with mocked IB
+  - Live trade requires explicit confirmation text
+
+---
+
+## Task 5.5: M5 Validation
+
+**Files to create**:
+- `epa/tests/test_m5_e2e.py`
+
+**Test cases** (require TWS paper trading running):
+1. `epa analyze AAPL --provider ibkr --budget 65000` → recommendation using live IBKR data
+2. Compare IBKR data vs yfinance data for same ticker → verify IBKR has better Greeks
+3. `epa execute AAPL --paper` → paper trade placed successfully
+4. Verify trade result saved to store
+5. `epa review AAPL` → includes actual trade P&L from paper account
+
+**Validation script** (manual):
+```bash
+# Requires TWS Paper Trading running on port 7497
+epa analyze AAPL --provider ibkr --budget 65000
+epa execute AAPL --paper
+# Wait for fill...
+epa review AAPL  # After earnings
+```
+
+**Done when**: Karl can go from analysis to paper trade execution in a single CLI session, with live IBKR data powering the analysis and paper trades testing the recommendations.
+
+---
+
+## Safety Notes
+
+- **Paper trading is always the default**. Live trading requires `--live` flag AND explicit confirmation.
+- **No auto-execution**. Even with IBKR connected, the system recommends — Karl decides and confirms.
+- **Position limits**: System respects the max_risk_pct cap regardless of Kelly output. No single trade can exceed the configured risk budget.
+- **IBKR credentials**: Handled entirely by TWS/Gateway. This tool never touches login credentials.

--- a/docs/designs/earnings-play-analyzer/implementation/OVERVIEW.md
+++ b/docs/designs/earnings-play-analyzer/implementation/OVERVIEW.md
@@ -1,0 +1,46 @@
+# Earnings Play Analyzer — Implementation Overview
+
+## Milestone Map
+
+```
+M1: Data Foundation          M2: Analysis Engine         M3: Opus Reasoning
+[data models, yfinance,      [edge calc, Kelly,          [Anthropic API,
+ SQLite store, basic CLI]     structures, scoring]        prompts, E2E flow]
+        │                           │                           │
+        └───────────┬───────────────┘                           │
+                    │                                           │
+                    └──────────────────┬────────────────────────┘
+                                       │
+                              M4: ktrdr Integration      M5: IBKR Integration
+                              [signal adapter,           [live data, paper
+                               directional logic]         trading, full flow]
+```
+
+## Milestone Summary
+
+| Milestone | Goal | Key Deliverable | Estimated Tasks |
+|-----------|------|-----------------|-----------------|
+| **M1** | Data pipeline works end-to-end | `epa analyze AAPL` prints raw earnings data + IV stats | 7 tasks |
+| **M2** | Analysis engine produces structured recommendations | Edge estimate + Kelly sizing + structure selection (no LLM) | 6 tasks |
+| **M3** | Full E2E with Opus reasoning | `epa analyze AAPL` → recommendation with natural language rationale | 5 tasks |
+| **M4** | ktrdr signal integration | Directional signal modifies structure selection | 4 tasks |
+| **M5** | IBKR live data + paper trading | Real-time options data, paper trade placement | 5 tasks |
+
+**Total: 27 tasks across 5 milestones**
+
+## Dependency Graph
+
+- M1 has no dependencies (start here)
+- M2 depends on M1 (needs data models and data layer)
+- M3 depends on M2 (needs analysis outputs to feed to Opus)
+- M4 depends on M2 (needs structure selector to modify)
+- M5 depends on M1 (needs data provider interface to implement)
+- M4 and M5 can be developed in parallel after M2/M3
+
+## Conventions
+
+- All tasks target 1-4 hours of implementation time
+- Each task specifies: files to create/modify, behavior, and tests
+- Every milestone ends with a VALIDATION task that proves E2E functionality
+- Tests use pytest with fixtures in `epa/tests/fixtures/`
+- Code style: ruff, type hints, dataclasses


### PR DESCRIPTION
## Summary

Design documentation for the **Earnings Play Analyzer** — a pre-earnings options analysis tool that combines:
- Historical earnings move data (yfinance)
- Implied volatility analysis (IV rank, IV percentile)
- ktrdr directional signal (optional input)
- Claude Opus 4.7 reasoning for structure selection and rationale

Produced by the `fintech-design` squad using kdesign + kplan methodology.

## What's Here

- `DESIGN.md` — problem statement, workflow, data sources, use cases, non-goals, open decisions
- `ARCHITECTURE.md` — components, data flow, SQLite schema, interface signatures
- `REVIEW.md` — design review (verdict: PROCEED)
- `implementation/OVERVIEW.md` — milestone map and dependency graph
- `implementation/M1_data_foundation.md` — data pipeline, yfinance, SQLite, basic CLI (7 tasks)
- `implementation/M2_analysis_engine.md` — edge calc, Kelly sizing, structure selection (6 tasks)
- `implementation/M3_opus_reasoning.md` — Anthropic API, prompts, E2E flow (5 tasks)
- `implementation/M4_ktrdr_integration.md` — signal adapter, directional logic (4 tasks)
- `implementation/M5_ibkr_integration.md` — live data, paper trading (5 tasks)

## Open Decisions (Karl to resolve)

1. ktrdr signal format — JSON file schema and write location
2. Watchlist scope — affects caching strategy
3. Account sizing — per-run vs configured once
4. Risk appetite — is 2% max per trade correct?
5. yfinance earnings date reliability — any known gaps?
6. Deployment target — Mac only or also Azure ACA?

## Next Step

Karl reviews and answers open decisions → implementation starts at M1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)