### PR TITLE
docs: Autonomous Options Trading System — design, architecture, implementation plan

### DIFF
--- a/docs/designs/autonomous-options-trading/ARCHITECTURE.md
+++ b/docs/designs/autonomous-options-trading/ARCHITECTURE.md
@@ -1,0 +1,2614 @@
+# ktrdr Autonomous Options Trading System — Architecture Document
+
+> **Author**: Claude (Opus 4.6), commissioned by Karl Piteira
+> **Date**: 2026-04-18
+> **Status**: Architecture — ready for implementation
+> **Based on**: DESIGN.md (approved), KTRDR_REALITY_MAP.md, Kronos spec (spec.md)
+
+---
+
+## 1. System Diagram (Detailed)
+
+### Deployment Topology
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│  Lux Process (Python 3.12, long-running)                                        │
+│                                                                                 │
+│  ┌──────────────────┐   ┌────────────────────┐   ┌─────────────────────┐       │
+│  │ LuxOrchestrator   │──>│ KtrdrSignalClient  │──>│ ktrdr REST API      │       │
+│  │ (main loop)       │   │ (HTTP client)      │   │ (separate process)  │       │
+│  │                   │   │                    │   │ localhost:8000      │       │
+│  │                   │   │ POST /api/v1/      │   │                     │       │
+│  │                   │   │ models/predict     │   │ Returns:            │       │
+│  │                   │   │                    │<──│ PredictionResponse  │       │
+│  │                   │   │ KtrdrSignal        │   │ + probabilities     │       │
+│  │                   │   └────────────────────┘   └─────────────────────┘       │
+│  │                   │                                                          │
+│  │                   │   ┌────────────────────┐   ┌─────────────────────┐       │
+│  │                   │──>│ KronosVolClassifier │   │ Kronos-mini (4.1M)  │       │
+│  │                   │   │ (in-process)       │──>│ Frozen weights      │       │
+│  │                   │   │                    │   │ + Linear(256->3)    │       │
+│  │                   │   │ VolRegimeSignal    │<──│ Trained head        │       │
+│  │                   │   └────────────────────┘   └─────────────────────┘       │
+│  │                   │                                                          │
+│  │                   │   ┌────────────────────┐   ┌─────────────────────┐       │
+│  │                   │──>│ OptionsDataProvider │──>│ yfinance (backtest) │       │
+│  │                   │   │                    │   │ IBKR MCP (live)     │       │
+│  │                   │   │ OptionsChain,      │   └─────────────────────┘       │
+│  │                   │   │ IVData             │                                 │
+│  │                   │   └────────────────────┘                                 │
+│  │                   │                                                          │
+│  │                   │   ┌────────────────────┐                                 │
+│  │                   │──>│ SignalAggregator   │                                 │
+│  │                   │   │                    │                                 │
+│  │                   │   │ DecisionInput      │                                 │
+│  │                   │   └────────┬───────────┘                                 │
+│  │                   │            │                                              │
+│  │                   │            v                                              │
+│  │                   │   ┌────────────────────┐   ┌─────────────────────┐       │
+│  │                   │   │ OpusStrategyAdvisor│──>│ Anthropic API       │       │
+│  │                   │   │                    │   │ Opus 4.7            │       │
+│  │                   │   │ TradeRecommendation│<──│ Extended thinking   │       │
+│  │                   │   │                    │   └─────────────────────┘       │
+│  │                   │   │ Fallback:          │                                 │
+│  │                   │   │ OptionsDecisionMat.│                                 │
+│  │                   │   └────────┬───────────┘                                 │
+│  │                   │            │                                              │
+│  │                   │            v                                              │
+│  │                   │   ┌────────────────────┐   ┌─────────────────────┐       │
+│  │                   │──>│ OptionsPosition    │──>│ SQLite              │       │
+│  │                   │   │ Manager            │   │ positions, trades,  │       │
+│  │                   │   │                    │   │ signals             │       │
+│  │                   │   └────────┬───────────┘   └─────────────────────┘       │
+│  │                   │            │                                              │
+│  │                   │            v                                              │
+│  │                   │   ┌────────────────────┐   ┌─────────────────────┐       │
+│  │                   │   │ Execution          │──>│ IBKR MCP (paper)    │       │
+│  │                   │   │                    │   │ IBKR MCP (live)     │       │
+│  │                   │   └────────────────────┘   └─────────────────────┘       │
+│  │                   │                                                          │
+│  │                   │   ┌────────────────────┐   ┌─────────────────────┐       │
+│  │                   │──>│ Telegram Reporter  │──>│ Telegram Bot API    │       │
+│  │                   │   └────────────────────┘   └─────────────────────┘       │
+│  └──────────────────┘                                                           │
+│                                                                                 │
+│  ┌──────────────────────────────────────────────────────────────────────────┐   │
+│  │ OptionsBacktestEngine (batch job, not long-running)                      │   │
+│  │                                                                          │   │
+│  │  Imports from ktrdr (in-process, library usage):                         │   │
+│  │    DecisionFunction, ModelBundle, IndicatorEngine, FuzzyEngine,          │   │
+│  │    FuzzyNeuralProcessor                                                  │   │
+│  │                                                                          │   │
+│  │  ┌─────────────────┐  ┌──────────────────┐  ┌───────────────────┐       │   │
+│  │  │ BlackScholes     │  │ OptionsDecision  │  │ OptionsPosition   │       │   │
+│  │  │ Engine           │  │ Matrix           │  │ Manager           │       │   │
+│  │  └─────────────────┘  └──────────────────┘  └───────────────────┘       │   │
+│  │                                                                          │   │
+│  │  Output: SQLite (backtest_runs, backtest_trades)                         │   │
+│  └──────────────────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│  ktrdr Process (separate, persistent, localhost:8000)                            │
+│                                                                                 │
+│  FastAPI server with loaded model(s)                                            │
+│  POST /api/v1/models/predict  ->  PredictionResponse (with probabilities)       │
+│                                                                                 │
+│  Internal pipeline:                                                             │
+│    OHLCV -> IndicatorEngine -> FuzzyEngine -> FuzzyNeuralProcessor              │
+│         -> NeuralModel.predict() -> DecisionOrchestrator -> response            │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Data Type Flow
+
+```
+OHLCV (pd.DataFrame)
+    │
+    ├──[KtrdrSignalClient]──HTTP POST──> ktrdr REST API
+    │                                         │
+    │                              PredictionResponse (JSON)
+    │                                         │
+    │                              KtrdrSignal (dataclass)
+    │                                         │
+    ├──[KronosVolClassifier]──torch.Tensor──> Kronos-mini
+    │                                         │
+    │                              VolRegimeSignal (dataclass)
+    │                                         │
+    ├──[OptionsDataProvider]──HTTP──> yfinance / IBKR
+    │                                         │
+    │                              OptionsChain (dataclass)
+    │                              IVData (dataclass)
+    │                                         │
+    └──[SignalAggregator]──────────> DecisionInput (dataclass, JSON-serializable)
+                                              │
+                                   ┌──────────┴──────────┐
+                                   │                     │
+                          [OpusStrategyAdvisor]   [OptionsDecisionMatrix]
+                           (live/paper)           (backtest / fallback)
+                                   │                     │
+                                   └──────────┬──────────┘
+                                              │
+                                   TradeRecommendation (dataclass)
+                                              │
+                                   [OptionsPositionManager]
+                                              │
+                                   OptionsPosition (dataclass) ──> SQLite
+```
+
+---
+
+## 2. Component Specifications
+
+### A. KronosVolClassifier
+
+**File**: `ktrdr_options/signals/kronos_classifier.py`
+
+```python
+from dataclasses import dataclass
+from typing import Optional
+import torch
+import torch.nn as nn
+import pandas as pd
+
+@dataclass
+class VolRegimeSignal:
+    regime: str                    # "SELL_VOL" | "BUY_VOL" | "NEUTRAL"
+    confidence: float              # max probability (0.0-1.0)
+    probabilities: dict[str, float]  # {"SELL_VOL": float, "BUY_VOL": float, "NEUTRAL": float}
+    iv_rank: float                 # current IV rank (0-100)
+    timestamp: str                 # ISO 8601
+
+REGIME_LABELS: dict[int, str] = {0: "NEUTRAL", 1: "SELL_VOL", 2: "BUY_VOL"}
+
+class KronosVolClassifier:
+    """
+    Loads frozen Kronos-mini transformer, extracts hidden states,
+    and classifies vol regime via a trained linear head.
+    """
+
+    def __init__(
+        self,
+        kronos_model_name: str = "NeoQuasar/Kronos-mini",
+        tokenizer_name: str = "NeoQuasar/Kronos-Tokenizer-2k",
+        classifier_weights_path: Optional[str] = None,
+        device: str = "cpu",
+        embedding_dim: int = 256,
+        num_classes: int = 3,
+        pooling: str = "last",  # "last" | "mean"
+    ) -> None: ...
+
+    # --- Public Methods ---
+
+    def load_model(self) -> None:
+        """
+        Load Kronos-mini and tokenizer from HuggingFace.
+        Freeze all Kronos parameters. Load classifier head weights
+        from classifier_weights_path if provided.
+        Raises RuntimeError if model weights cannot be loaded.
+        """
+        ...
+
+    def predict(
+        self,
+        ohlcv: pd.DataFrame,
+        iv_rank: float,
+        timestamp: Optional[str] = None,
+    ) -> VolRegimeSignal:
+        """
+        Run Kronos forward pass on OHLCV data, extract embedding,
+        classify vol regime via linear head.
+
+        Args:
+            ohlcv: DataFrame with columns [open, high, low, close, volume].
+                   Must have at least 50 rows. Uses last 512 rows if longer.
+            iv_rank: Current IV rank (0-100), included in output for context.
+            timestamp: ISO 8601 timestamp. Defaults to now.
+
+        Returns:
+            VolRegimeSignal with regime, confidence, probabilities, iv_rank.
+        """
+        ...
+
+    def extract_embedding(self, ohlcv: pd.DataFrame) -> torch.Tensor:
+        """
+        Extract Kronos hidden state embedding from OHLCV data.
+
+        Args:
+            ohlcv: DataFrame with columns [open, high, low, close, volume].
+
+        Returns:
+            Tensor of shape (1, embedding_dim). Pooled according to self.pooling.
+        """
+        ...
+
+    def extract_embeddings_batched(
+        self,
+        ohlcv: pd.DataFrame,
+        window_size: int = 512,
+        stride: int = 1,
+    ) -> torch.Tensor:
+        """
+        Sliding-window embedding extraction for training/caching.
+
+        Args:
+            ohlcv: Full historical OHLCV DataFrame.
+            window_size: Number of bars per window.
+            stride: Step between windows.
+
+        Returns:
+            Tensor of shape (num_windows, embedding_dim).
+        """
+        ...
+
+    def train_classifier(
+        self,
+        embeddings: torch.Tensor,
+        labels: torch.Tensor,
+        val_embeddings: torch.Tensor,
+        val_labels: torch.Tensor,
+        epochs: int = 100,
+        lr: float = 0.001,
+        class_weights: Optional[torch.Tensor] = None,
+    ) -> dict[str, float]:
+        """
+        Train the linear classifier head on pre-computed embeddings.
+
+        Args:
+            embeddings: (N, embedding_dim) tensor of Kronos embeddings.
+            labels: (N,) tensor of integer labels (0=NEUTRAL, 1=SELL_VOL, 2=BUY_VOL).
+            val_embeddings: Validation embeddings.
+            val_labels: Validation labels.
+            epochs: Max training epochs.
+            lr: Learning rate.
+            class_weights: Optional tensor for weighted cross-entropy.
+
+        Returns:
+            Dict with keys: "train_loss", "val_loss", "val_auc", "val_accuracy",
+            "per_class_precision", "per_class_recall".
+        """
+        ...
+
+    def save_classifier(self, path: str) -> None:
+        """Save classifier head weights and config to path."""
+        ...
+
+    def load_classifier(self, path: str) -> None:
+        """Load classifier head weights from path."""
+        ...
+
+    # --- Internal State ---
+    # self._kronos_model: Kronos (frozen)
+    # self._tokenizer: KronosTokenizer
+    # self._classifier: nn.Linear(embedding_dim, num_classes)
+    # self._device: str
+    # self._pooling: str ("last" | "mean")
+    # self._embedding_dim: int
+    # self._is_loaded: bool
+```
+
+### B. KtrdrSignalClient
+
+**File**: `ktrdr_options/signals/ktrdr_client.py`
+
+```python
+import httpx
+from dataclasses import dataclass
+
+@dataclass
+class KtrdrSignal:
+    signal: str                        # "BUY" | "SELL" | "HOLD"
+    confidence: float                  # max probability (0.0-1.0)
+    signal_strength: float             # 0.0-1.0
+    probabilities: dict[str, float]    # {"BUY": float, "HOLD": float, "SELL": float}
+    model_name: str
+    symbol: str
+    timeframe: str
+    test_date: str                     # ISO 8601
+    input_features: dict[str, float]   # fuzzy feature values
+
+class KtrdrSignalClient:
+    """
+    HTTP client for ktrdr REST API.
+    Calls POST /api/v1/models/predict and returns extended KtrdrSignal.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8000",
+        timeout_seconds: float = 30.0,
+        max_retries: int = 3,
+        retry_backoff_base: float = 2.0,
+    ) -> None: ...
+
+    async def predict(
+        self,
+        model_name: str,
+        symbol: str,
+        timeframe: str = "1h",
+        test_date: str | None = None,
+    ) -> KtrdrSignal:
+        """
+        Call ktrdr prediction endpoint with retries.
+
+        Args:
+            model_name: Trained model name (e.g., "trend_tb_lstm_signal_v1").
+            symbol: Ticker symbol (e.g., "SPY").
+            timeframe: Bar timeframe (e.g., "1h", "1d").
+            test_date: Optional ISO 8601 datetime. Defaults to latest bar.
+
+        Returns:
+            KtrdrSignal with full probability distribution.
+
+        Raises:
+            KtrdrAPIError: After max_retries exhausted.
+            KtrdrStaleDataError: If response test_date is >2 bars behind current time.
+        """
+        ...
+
+    async def health_check(self) -> bool:
+        """Check if ktrdr server is reachable. Returns True/False."""
+        ...
+
+    # --- Internal State ---
+    # self._client: httpx.AsyncClient
+    # self._base_url: str
+    # self._max_retries: int
+    # self._retry_backoff_base: float
+```
+
+### C. OptionsDataProvider
+
+**File**: `ktrdr_options/data/options_data.py`
+
+```python
+from dataclasses import dataclass, field
+import pandas as pd
+
+@dataclass
+class OptionContract:
+    strike: float
+    expiry: str              # ISO 8601 date
+    option_type: str         # "CALL" | "PUT"
+    bid: float
+    ask: float
+    iv: float                # implied volatility (annualized, decimal)
+    delta: float
+    gamma: float
+    theta: float
+    vega: float
+    open_interest: int
+    volume: int
+
+@dataclass
+class OptionsChain:
+    symbol: str
+    underlying_price: float
+    timestamp: str           # ISO 8601
+    expiries: list[str]      # available expiry dates
+    contracts: list[OptionContract]
+
+@dataclass
+class IVData:
+    current_iv: float        # annualized, decimal (e.g., 0.22)
+    iv_rank: float           # 0-100
+    iv_percentile: float     # 0-100
+    iv_history: pd.Series    # trailing 252-day IV series
+    vix: float               # current VIX level
+    rv_20d: float            # 20-day realized vol (annualized, decimal)
+
+class OptionsDataProvider:
+    """
+    Fetches options chain data and IV context.
+    Uses yfinance for backtesting / free path.
+    Uses IBKR MCP for paper/live trading.
+    """
+
+    def __init__(
+        self,
+        mode: str = "backtest",  # "backtest" | "paper" | "live"
+        ibkr_config: dict | None = None,
+    ) -> None: ...
+
+    async def get_options_chain(
+        self,
+        symbol: str,
+        min_dte: int = 14,
+        max_dte: int = 60,
+        min_delta: float = 0.10,
+        max_delta: float = 0.50,
+    ) -> OptionsChain:
+        """
+        Fetch current options chain filtered by DTE and delta range.
+
+        Args:
+            symbol: Underlying ticker.
+            min_dte: Minimum days to expiry.
+            max_dte: Maximum days to expiry.
+            min_delta: Minimum absolute delta.
+            max_delta: Maximum absolute delta.
+
+        Returns:
+            OptionsChain with filtered contracts.
+
+        Raises:
+            OptionsDataError: If data source unavailable.
+        """
+        ...
+
+    async def get_iv_data(
+        self,
+        symbol: str,
+        as_of: str | None = None,
+    ) -> IVData:
+        """
+        Compute IV rank and related vol context for symbol.
+
+        Args:
+            symbol: Ticker symbol.
+            as_of: Date for historical lookback (ISO 8601). Defaults to today.
+
+        Returns:
+            IVData with iv_rank, current_iv, rv_20d, vix.
+        """
+        ...
+
+    def compute_iv_rank(
+        self,
+        iv_current: float,
+        iv_history_252d: pd.Series,
+    ) -> float:
+        """
+        IV Rank = (current - 252d low) / (252d high - 252d low) * 100.
+        Returns 50.0 if high == low (no range).
+        """
+        ...
+
+    def compute_realized_vol(
+        self,
+        prices: pd.Series,
+        window: int = 20,
+    ) -> float:
+        """
+        Annualized realized volatility from close prices.
+        = rolling std(log returns) * sqrt(252)
+        """
+        ...
+
+    async def get_vix_history(
+        self,
+        start: str,
+        end: str,
+    ) -> pd.Series:
+        """
+        Fetch VIX daily close from yfinance.
+        Returns pd.Series with DatetimeIndex.
+        """
+        ...
+
+    async def get_risk_free_rate(self, as_of: str | None = None) -> float:
+        """
+        Fetch 3-month Treasury bill rate from FRED.
+        Returns annualized rate as decimal (e.g., 0.05 for 5%).
+        """
+        ...
+
+    # --- Internal State ---
+    # self._mode: str
+    # self._vix_cache: pd.Series | None
+    # self._rate_cache: dict[str, float]
+```
+
+### D. SignalAggregator
+
+**File**: `ktrdr_options/signals/aggregator.py`
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class DecisionInput:
+    """Complete structured input for Opus 4.7 or OptionsDecisionMatrix."""
+
+    # Metadata
+    timestamp: str           # ISO 8601
+    symbol: str
+
+    # Underlying
+    current_price: float
+    price_change_1d: float
+    price_change_5d: float
+
+    # ktrdr signal
+    ktrdr_signal: str        # "BUY" | "SELL" | "HOLD"
+    ktrdr_confidence: float
+    ktrdr_probabilities: dict[str, float]
+    ktrdr_model_name: str
+    ktrdr_timeframe: str
+
+    # Kronos regime
+    kronos_regime: str       # "SELL_VOL" | "BUY_VOL" | "NEUTRAL"
+    kronos_confidence: float
+    kronos_probabilities: dict[str, float]
+
+    # Vol context
+    iv_rank: float           # 0-100
+    current_iv: float        # annualized decimal
+    vix: float
+    rv_20d: float            # annualized decimal
+
+    # Options chain (for live/paper)
+    options_chain: dict | None = None  # serialized OptionsChain
+
+    # Portfolio state
+    account_value: float = 100_000.0
+    buying_power: float = 100_000.0
+    open_positions_count: int = 0
+    max_risk_per_trade: float = 2_000.0
+
+    # Decision matrix pre-computation
+    matrix_suggestion: str | None = None  # suggested structure name
+    matrix_reasoning: str | None = None
+
+    def to_dict(self) -> dict:
+        """JSON-serializable dict for Opus 4.7 prompt or logging."""
+        ...
+
+    def to_json(self) -> str:
+        """JSON string representation."""
+        ...
+
+
+class SignalAggregator:
+    """
+    Combines ktrdr directional signal + Kronos vol regime + options context
+    into a unified DecisionInput for downstream decision-making.
+    """
+
+    def __init__(
+        self,
+        account_value: float = 100_000.0,
+        max_risk_pct: float = 0.02,
+    ) -> None: ...
+
+    def aggregate(
+        self,
+        ktrdr_signal: "KtrdrSignal",
+        kronos_regime: "VolRegimeSignal",
+        iv_data: "IVData",
+        current_price: float,
+        price_history_5d: list[float] | None = None,
+        options_chain: "OptionsChain | None" = None,
+        portfolio_state: dict | None = None,
+    ) -> DecisionInput:
+        """
+        Combine all signal sources into a single DecisionInput.
+
+        Computes:
+        - price_change_1d, price_change_5d from price_history_5d
+        - max_risk_per_trade = account_value * max_risk_pct * position_size_multiplier
+        - matrix_suggestion via OptionsDecisionMatrix.suggest()
+
+        Args:
+            ktrdr_signal: KtrdrSignal from KtrdrSignalClient.
+            kronos_regime: VolRegimeSignal from KronosVolClassifier.
+            iv_data: IVData from OptionsDataProvider.
+            current_price: Current underlying price.
+            price_history_5d: Last 5 daily closes for computing changes.
+            options_chain: OptionsChain for live/paper mode.
+            portfolio_state: Dict with account_value, buying_power, open_positions.
+
+        Returns:
+            DecisionInput ready for OpusStrategyAdvisor or OptionsDecisionMatrix.
+        """
+        ...
+
+    def compute_position_size_multiplier(
+        self,
+        max_probability: float,
+        probability_spread: float,
+    ) -> float:
+        """
+        Compute position size multiplier from ktrdr probability distribution.
+
+        probability_spread < 0.10 -> 0.5
+        probability_spread < 0.25 -> 0.75
+        else -> 1.0
+
+        Returns: 0.5, 0.75, or 1.0
+        """
+        ...
+
+    # --- Internal State ---
+    # self._account_value: float
+    # self._max_risk_pct: float
+    # self._decision_matrix: OptionsDecisionMatrix (for pre-computing suggestion)
+```
+
+### E. OptionsDecisionMatrix
+
+**File**: `ktrdr_options/strategy/decision_matrix.py`
+
+```python
+from dataclasses import dataclass
+from enum import Enum
+
+class StructureType(Enum):
+    BULL_PUT_SPREAD = "bull_put_spread"
+    IRON_CONDOR = "iron_condor"
+    BULL_CALL_SPREAD = "bull_call_spread"
+    BEAR_CALL_SPREAD = "bear_call_spread"
+    LONG_CALL = "long_call"
+    LONG_STRADDLE = "long_straddle"
+    BEAR_PUT_SPREAD = "bear_put_spread"
+    LONG_PUT = "long_put"
+    NO_TRADE = "no_trade"
+
+@dataclass
+class StructureChoice:
+    structure: StructureType
+    reasoning: str
+    confidence_gate_passed: bool
+    target_dte_min: int          # minimum DTE for this structure
+    target_dte_max: int          # maximum DTE for this structure
+    target_short_delta: float | None   # for credit spreads
+    target_long_delta: float | None    # for debit spreads / naked longs
+    spread_width_strikes: int | None   # number of strikes wide
+
+class OptionsDecisionMatrix:
+    """
+    Deterministic mapping: (ktrdr_signal, kronos_regime, iv_rank) -> StructureChoice.
+    Used in backtesting (no Opus 4.7 call) and as fallback in live trading.
+    """
+
+    def __init__(
+        self,
+        min_ktrdr_confidence: float = 0.45,
+        min_ktrdr_confidence_naked: float = 0.65,
+        min_kronos_confidence_vol: float = 0.70,
+        min_kronos_confidence_other: float = 0.50,
+    ) -> None: ...
+
+    def select(self, decision_input: "DecisionInput") -> StructureChoice:
+        """
+        Apply the decision matrix to produce a structure selection.
+
+        Matrix:
+                          SELL_VOL          NEUTRAL           BUY_VOL
+            BUY      Bull Put Spread   Bull Call Spread    Long Call
+            HOLD     Iron Condor       No Trade            Long Straddle
+            SELL     Bear Call Spread   Bear Put Spread     Long Put
+
+        Applies confidence gates:
+        - ktrdr max_probability >= min_ktrdr_confidence (all trades)
+        - ktrdr max_probability >= min_ktrdr_confidence_naked (long call/put)
+        - kronos confidence >= min_kronos_confidence_vol (iron condor, straddle)
+        - kronos confidence >= min_kronos_confidence_other (all other)
+
+        Returns NO_TRADE if gates fail.
+
+        Args:
+            decision_input: DecisionInput from SignalAggregator.
+
+        Returns:
+            StructureChoice with selected structure and parameters.
+        """
+        ...
+
+    def suggest(
+        self,
+        ktrdr_signal: str,
+        kronos_regime: str,
+    ) -> tuple[str, str]:
+        """
+        Quick lookup for matrix suggestion (structure name, reasoning).
+        Used by SignalAggregator for pre-populating DecisionInput.
+        Does NOT apply confidence gates.
+
+        Returns:
+            (structure_name, reasoning_text)
+        """
+        ...
+
+    # --- Internal State ---
+    # self._matrix: dict[tuple[str, str], StructureType]  # (signal, regime) -> structure
+    # self._structure_params: dict[StructureType, dict]    # DTE, delta, width defaults
+    # self._confidence_thresholds: dict[str, float]
+```
+
+### F. OpusStrategyAdvisor
+
+**File**: `ktrdr_options/strategy/opus_advisor.py`
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class OptionsLeg:
+    action: str              # "BUY" | "SELL"
+    option_type: str         # "CALL" | "PUT"
+    strike: float
+    expiry: str              # ISO 8601 date
+    contracts: int
+    estimated_price: float   # per-contract price
+
+@dataclass
+class ExitPlan:
+    take_profit_pct: float   # e.g., 50.0 = close at 50% of max profit
+    stop_loss_pct: float     # e.g., 100.0 = close at max loss
+    time_exit_dte: int       # close when DTE falls below this
+    signal_reversal_exit: bool = True  # exit on ktrdr signal flip
+
+@dataclass
+class TradeRecommendation:
+    action: str              # "OPEN" | "CLOSE" | "ADJUST" | "HOLD"
+    structure: str           # StructureType value string
+    legs: list[OptionsLeg]
+    expected_credit: float | None    # net credit for credit spreads
+    expected_debit: float | None     # net debit for debit spreads
+    max_risk: float          # max loss in dollars
+    max_profit: float        # max profit in dollars
+    breakeven: float | list[float]   # breakeven price(s)
+    exit_plan: ExitPlan
+    reasoning: str           # human-readable explanation
+    confidence: str          # "HIGH" | "MEDIUM" | "LOW"
+    warnings: list[str]
+    source: str              # "opus" | "matrix"  (was Opus used or fallback?)
+
+class OpusStrategyAdvisor:
+    """
+    Calls Opus 4.7 via Anthropic API with structured prompt.
+    Validates output against risk limits and allowed structures.
+    Falls back to OptionsDecisionMatrix on failure.
+    """
+
+    ALLOWED_STRUCTURES: set[str] = {
+        "bull_put_spread", "iron_condor", "bull_call_spread",
+        "bear_call_spread", "long_call", "long_straddle",
+        "bear_put_spread", "long_put",
+    }
+
+    def __init__(
+        self,
+        anthropic_api_key: str,
+        model: str = "claude-opus-4-7-20260401",
+        timeout_seconds: float = 60.0,
+        max_retries: int = 2,
+        fallback_matrix: "OptionsDecisionMatrix | None" = None,
+    ) -> None: ...
+
+    async def advise(
+        self,
+        decision_input: "DecisionInput",
+    ) -> TradeRecommendation:
+        """
+        Send structured prompt to Opus 4.7, parse and validate response.
+
+        Flow:
+        1. Build structured JSON prompt from DecisionInput
+        2. Call Anthropic API with extended thinking enabled
+        3. Parse JSON response
+        4. Validate: structure in ALLOWED_STRUCTURES, max_risk <= decision_input.max_risk_per_trade,
+           all legs have valid strikes/expiries
+        5. If validation fails after max_retries, fall back to OptionsDecisionMatrix
+
+        Args:
+            decision_input: Complete DecisionInput from SignalAggregator.
+
+        Returns:
+            Validated TradeRecommendation. source="opus" if Opus succeeded,
+            source="matrix" if fallback was used.
+        """
+        ...
+
+    def _build_prompt(self, decision_input: "DecisionInput") -> str:
+        """Build the structured JSON prompt for Opus 4.7."""
+        ...
+
+    def _parse_response(self, response_text: str) -> TradeRecommendation:
+        """
+        Parse Opus JSON response into TradeRecommendation.
+        Raises ValueError if JSON is malformed or missing required fields.
+        """
+        ...
+
+    def _validate_recommendation(
+        self,
+        recommendation: TradeRecommendation,
+        decision_input: "DecisionInput",
+    ) -> list[str]:
+        """
+        Validate recommendation against risk limits.
+        Returns list of validation errors (empty = valid).
+
+        Checks:
+        - structure in ALLOWED_STRUCTURES
+        - max_risk <= decision_input.max_risk_per_trade
+        - all legs reference valid strikes from options chain
+        - contracts > 0
+        - expiry in future
+        """
+        ...
+
+    def _fallback_to_matrix(
+        self,
+        decision_input: "DecisionInput",
+        reason: str,
+    ) -> TradeRecommendation:
+        """
+        Generate TradeRecommendation from OptionsDecisionMatrix.
+        source="matrix", reasoning includes fallback reason.
+        """
+        ...
+
+    # --- Internal State ---
+    # self._client: anthropic.AsyncAnthropic
+    # self._model: str
+    # self._timeout: float
+    # self._max_retries: int
+    # self._fallback_matrix: OptionsDecisionMatrix
+```
+
+### G. BlackScholesEngine
+
+**File**: `ktrdr_options/backtest/black_scholes.py`
+
+```python
+from dataclasses import dataclass
+import numpy as np
+
+@dataclass
+class OptionPrice:
+    price: float          # theoretical price
+    delta: float
+    gamma: float
+    theta: float          # per calendar day
+    vega: float           # per 1% vol change
+    rho: float
+
+class BlackScholesEngine:
+    """
+    Pure-math Black-Scholes pricing and Greeks computation.
+    No external dependencies beyond numpy/scipy.
+    """
+
+    def __init__(
+        self,
+        bid_ask_haircut: float = 0.10,  # 10% flat haircut
+    ) -> None: ...
+
+    def price_call(
+        self,
+        S: float,    # underlying price
+        K: float,    # strike
+        T: float,    # time to expiry in years
+        r: float,    # risk-free rate (annualized, decimal)
+        sigma: float,  # implied volatility (annualized, decimal)
+    ) -> OptionPrice:
+        """
+        Black-Scholes call pricing with all Greeks.
+
+        C = S * N(d1) - K * e^(-rT) * N(d2)
+        d1 = (ln(S/K) + (r + sigma^2/2) * T) / (sigma * sqrt(T))
+        d2 = d1 - sigma * sqrt(T)
+
+        Returns OptionPrice with price, delta, gamma, theta, vega, rho.
+        """
+        ...
+
+    def price_put(
+        self,
+        S: float, K: float, T: float, r: float, sigma: float,
+    ) -> OptionPrice:
+        """
+        Black-Scholes put pricing with all Greeks.
+
+        P = K * e^(-rT) * N(-d2) - S * N(-d1)
+
+        Returns OptionPrice with price, delta (negative), gamma, theta, vega, rho.
+        """
+        ...
+
+    def price_option(
+        self,
+        S: float, K: float, T: float, r: float, sigma: float,
+        option_type: str,  # "CALL" | "PUT"
+    ) -> OptionPrice:
+        """Dispatch to price_call or price_put."""
+        ...
+
+    def find_strike_by_delta(
+        self,
+        S: float,
+        T: float,
+        r: float,
+        sigma: float,
+        target_delta: float,  # e.g., 0.30 for call, -0.30 for put
+        option_type: str,
+        strike_step: float = 1.0,  # round to nearest strike_step
+    ) -> float:
+        """
+        Find the strike price that produces the target delta.
+        Uses Newton's method on the delta function.
+        Rounds to nearest strike_step.
+
+        Args:
+            target_delta: Positive for calls, negative for puts.
+            strike_step: Strike rounding (e.g., 1.0 for SPY, 5.0 for SPX).
+
+        Returns:
+            Strike price (float).
+        """
+        ...
+
+    def apply_haircut(
+        self,
+        price: float,
+        side: str,  # "credit" | "debit"
+    ) -> float:
+        """
+        Apply bid/ask haircut to theoretical price.
+
+        credit: price * (1 - haircut)  # you receive less
+        debit:  price * (1 + haircut)  # you pay more
+
+        Returns adjusted price.
+        """
+        ...
+
+    def price_spread(
+        self,
+        S: float,
+        legs: list["OptionsLeg"],
+        T: float,
+        r: float,
+        sigma: float,
+    ) -> dict[str, float]:
+        """
+        Price a multi-leg structure. Returns:
+        {
+            "net_price": float,       # positive = credit, negative = debit
+            "max_profit": float,
+            "max_loss": float,
+            "breakeven": float | list[float],
+            "net_delta": float,
+            "net_gamma": float,
+            "net_theta": float,
+            "net_vega": float,
+        }
+        """
+        ...
+
+    @staticmethod
+    def estimate_iv_from_vix(
+        vix: float,
+        beta: float = 1.0,
+    ) -> float:
+        """
+        Estimate single-name IV from VIX.
+        sigma = VIX / 100 * max(0.8, min(2.0, beta * 0.9 + 0.3))
+
+        Args:
+            vix: VIX level (e.g., 22.4)
+            beta: Stock beta relative to S&P 500.
+
+        Returns:
+            Annualized IV as decimal (e.g., 0.224).
+        """
+        ...
+
+    # --- Internal State ---
+    # self._haircut: float
+```
+
+### H. OptionsPosition
+
+**File**: `ktrdr_options/positions/position.py`
+
+```python
+from dataclasses import dataclass, field
+from enum import Enum
+from datetime import datetime
+
+class PositionStatus(Enum):
+    OPEN = "OPEN"
+    CLOSED = "CLOSED"
+    EXPIRED = "EXPIRED"
+
+@dataclass
+class OptionsLeg:
+    leg_id: str                    # UUID
+    action: str                    # "BUY" | "SELL"
+    option_type: str               # "CALL" | "PUT"
+    strike: float
+    expiry: str                    # ISO 8601 date
+    contracts: int
+    entry_price: float             # per-contract price at entry
+    current_price: float = 0.0     # per-contract price at current mark
+    current_delta: float = 0.0
+    current_gamma: float = 0.0
+    current_theta: float = 0.0
+    current_vega: float = 0.0
+
+@dataclass
+class OptionsPosition:
+    position_id: str               # UUID
+    symbol: str
+    structure: str                 # StructureType value
+    legs: list[OptionsLeg]
+    entry_timestamp: str           # ISO 8601
+    exit_timestamp: str | None = None
+
+    # Entry metrics
+    net_entry_price: float = 0.0   # positive = credit, negative = debit
+    max_profit: float = 0.0
+    max_loss: float = 0.0
+    breakeven: float | list[float] = field(default_factory=list)
+
+    # Current state
+    status: PositionStatus = PositionStatus.OPEN
+    current_pnl: float = 0.0      # unrealized P&L in dollars
+    current_pnl_pct: float = 0.0  # P&L as % of max risk
+    dte_remaining: int = 0
+
+    # Portfolio Greeks (net across all legs)
+    net_delta: float = 0.0
+    net_gamma: float = 0.0
+    net_theta: float = 0.0
+    net_vega: float = 0.0
+
+    # Exit plan (from TradeRecommendation)
+    take_profit_pct: float = 50.0
+    stop_loss_pct: float = 100.0
+    time_exit_dte: int = 7
+    signal_reversal_exit: bool = True
+
+    # Exit details (filled on close)
+    exit_reason: str | None = None
+    exit_pnl: float = 0.0
+
+    # Signal context at entry
+    ktrdr_signal: str = ""
+    kronos_regime: str = ""
+    iv_rank_at_entry: float = 0.0
+    recommendation_source: str = ""  # "opus" | "matrix"
+
+    def to_dict(self) -> dict:
+        """JSON-serializable dict for persistence."""
+        ...
+```
+
+### I. OptionsPositionManager
+
+**File**: `ktrdr_options/positions/manager.py`
+
+```python
+class OptionsPositionManager:
+    """
+    Creates, tracks, and exits options positions.
+    Computes portfolio-level Greeks. Persists to SQLite.
+    """
+
+    def __init__(
+        self,
+        db_path: str = "ktrdr_options.db",
+        bs_engine: "BlackScholesEngine | None" = None,
+    ) -> None: ...
+
+    def open_position(
+        self,
+        recommendation: "TradeRecommendation",
+        decision_input: "DecisionInput",
+    ) -> OptionsPosition:
+        """
+        Create a new OptionsPosition from a TradeRecommendation.
+        Persists to SQLite positions table.
+
+        Args:
+            recommendation: Validated TradeRecommendation.
+            decision_input: DecisionInput that produced the recommendation.
+
+        Returns:
+            New OptionsPosition with OPEN status.
+        """
+        ...
+
+    def mark_to_market(
+        self,
+        position: OptionsPosition,
+        underlying_price: float,
+        current_iv: float,
+        risk_free_rate: float,
+        current_date: str,
+    ) -> OptionsPosition:
+        """
+        Update position's current prices, Greeks, and P&L using Black-Scholes.
+
+        Updates: current_pnl, current_pnl_pct, net_delta/gamma/theta/vega,
+        dte_remaining, and each leg's current_price and Greeks.
+
+        Returns updated OptionsPosition (mutates in place AND returns).
+        """
+        ...
+
+    def check_exit_conditions(
+        self,
+        position: OptionsPosition,
+        current_ktrdr_signal: str,
+    ) -> tuple[bool, str]:
+        """
+        Check whether position should be closed.
+
+        Exit conditions (in priority order):
+        1. DTE < time_exit_dte -> "time_exit"
+        2. P&L >= take_profit_pct% of max_profit -> "take_profit"
+        3. P&L <= -stop_loss_pct% of max_loss (for credits) or debit lost -> "stop_loss"
+        4. ktrdr signal reversed (BUY->SELL or SELL->BUY) and signal_reversal_exit -> "signal_reversal"
+
+        Returns:
+            (should_exit: bool, reason: str)
+        """
+        ...
+
+    def close_position(
+        self,
+        position: OptionsPosition,
+        exit_reason: str,
+        exit_timestamp: str,
+    ) -> OptionsPosition:
+        """
+        Close position. Compute final exit_pnl. Update status to CLOSED.
+        Record trade in SQLite trades table.
+
+        Returns updated OptionsPosition.
+        """
+        ...
+
+    def get_open_positions(self) -> list[OptionsPosition]:
+        """Return all positions with status OPEN."""
+        ...
+
+    def get_portfolio_greeks(self) -> dict[str, float]:
+        """
+        Compute aggregate Greeks across all open positions.
+
+        Returns:
+        {
+            "total_delta": float,
+            "total_gamma": float,
+            "total_theta": float,
+            "total_vega": float,
+            "total_risk": float,    # sum of max_loss across open positions
+            "position_count": int,
+        }
+        """
+        ...
+
+    def get_position_history(
+        self,
+        symbol: str | None = None,
+        limit: int = 100,
+    ) -> list[OptionsPosition]:
+        """Return closed positions, most recent first."""
+        ...
+
+    # --- Internal State ---
+    # self._db: sqlite3.Connection
+    # self._bs_engine: BlackScholesEngine
+    # self._open_positions: list[OptionsPosition]  # in-memory cache of open positions
+```
+
+### J. OptionsBacktestEngine
+
+**File**: `ktrdr_options/backtest/engine.py`
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class OptionsBacktestConfig:
+    strategy_config_path: str      # path to ktrdr strategy YAML
+    model_path: str                # path to trained ktrdr model directory
+    symbol: str
+    timeframe: str                 # bar timeframe (e.g., "1h")
+    start_date: str                # ISO 8601
+    end_date: str                  # ISO 8601
+    initial_capital: float = 100_000.0
+    max_risk_pct: float = 0.02     # 2% per trade
+    bid_ask_haircut: float = 0.10  # 10% B-S haircut
+    vix_data_path: str | None = None  # optional cached VIX CSV
+    kronos_embeddings_path: str | None = None  # pre-computed .pt file
+    kronos_classifier_path: str | None = None  # trained classifier weights
+    db_path: str = "backtest_results.db"
+
+@dataclass
+class OptionsBacktestTrade:
+    trade_id: str                  # UUID
+    backtest_run_id: str
+    symbol: str
+    structure: str
+    entry_date: str
+    exit_date: str
+    entry_price: float             # net credit/debit
+    exit_price: float
+    pnl: float
+    pnl_pct: float                 # P&L as % of max risk
+    max_profit: float
+    max_loss: float
+    exit_reason: str
+    ktrdr_signal: str
+    kronos_regime: str
+    iv_rank: float
+    dte_at_entry: int
+    legs: list[dict]               # serialized OptionsLeg list
+
+@dataclass
+class OptionsBacktestResults:
+    run_id: str                    # UUID
+    config: OptionsBacktestConfig
+    trades: list[OptionsBacktestTrade]
+
+    # Performance metrics
+    total_return: float
+    total_return_pct: float
+    sharpe_ratio: float
+    max_drawdown_pct: float
+    win_rate: float
+    total_trades: int
+    winning_trades: int
+    losing_trades: int
+    profit_factor: float
+    avg_win_pct: float
+    avg_loss_pct: float
+    avg_dte_at_entry: float
+    avg_holding_period_days: float
+
+    # Options-specific metrics
+    avg_theta_collected: float     # avg daily theta on open positions
+    avg_delta_exposure: float      # avg net delta
+    gamma_risk_events: int         # times gamma > threshold near expiry
+    structure_breakdown: dict[str, int]  # trade count per structure type
+
+    # Time series
+    equity_curve: list[dict]       # [{date, equity, drawdown}, ...]
+    signal_distribution: dict[str, int]  # {"BUY": N, "SELL": N, "HOLD": N}
+
+    execution_time_seconds: float
+
+    def to_dict(self) -> dict:
+        """JSON-serializable dict."""
+        ...
+
+
+class OptionsBacktestEngine:
+    """
+    Drives the synthetic options backtest loop.
+    Reuses ktrdr's feature pipeline (DecisionFunction, ModelBundle) for signal generation.
+    Uses BlackScholesEngine for option pricing.
+    Writes results to SQLite.
+    """
+
+    def __init__(self, config: OptionsBacktestConfig) -> None: ...
+
+    def run(self) -> OptionsBacktestResults:
+        """
+        Execute the full backtest.
+
+        Flow per bar:
+        1. Generate ktrdr signal via DecisionFunction (reuses ktrdr feature pipeline)
+        2. Look up Kronos vol regime from pre-computed embeddings + classifier
+        3. Compute IV rank from VIX history
+        4. Apply OptionsDecisionMatrix -> StructureChoice
+        5. If structure != NO_TRADE and confidence gates pass:
+           a. Select strikes via BlackScholesEngine.find_strike_by_delta()
+           b. Compute entry price via BlackScholesEngine.price_spread()
+           c. Apply bid/ask haircut
+           d. Open position via OptionsPositionManager
+        6. For each open position:
+           a. Mark to market via BlackScholesEngine
+           b. Check exit conditions
+           c. Close if triggered
+        7. Record equity curve
+
+        Returns:
+            OptionsBacktestResults with full metrics and trade log.
+        """
+        ...
+
+    def _load_ktrdr_pipeline(self) -> None:
+        """
+        Load ktrdr model and feature pipeline.
+
+        Imports:
+            from ktrdr.backtesting.decision_function import DecisionFunction
+            from ktrdr.backtesting.model_bundle import ModelBundle
+            from ktrdr.indicators.indicator_engine import IndicatorEngine
+            from ktrdr.fuzzy.engine import FuzzyEngine
+            from ktrdr.training.fuzzy_neural_processor import FuzzyNeuralProcessor
+            from ktrdr.data.local_data_loader import LocalDataLoader
+            from ktrdr.config.feature_resolver import FeatureResolver
+        """
+        ...
+
+    def _load_kronos(self) -> None:
+        """Load KronosVolClassifier with pre-computed embeddings if available."""
+        ...
+
+    def _load_vix_data(self) -> None:
+        """Load VIX history. From file if vix_data_path set, else yfinance."""
+        ...
+
+    def _compute_ktrdr_signal(
+        self,
+        features: dict[str, float],
+        position_status: str,
+        bar: "pd.Series",
+        last_signal_time: "pd.Timestamp | None",
+    ) -> "TradingDecision":
+        """
+        Run ktrdr DecisionFunction for one bar.
+        Uses the same interface as ktrdr's BacktestingEngine.
+        """
+        ...
+
+    def _compute_kronos_regime(
+        self,
+        bar_index: int,
+        iv_rank: float,
+        timestamp: str,
+    ) -> "VolRegimeSignal":
+        """Look up pre-computed Kronos embedding, run classifier."""
+        ...
+
+    def _compute_iv_context(
+        self,
+        timestamp: "pd.Timestamp",
+        underlying_price: float,
+    ) -> tuple[float, float, float]:
+        """
+        Compute IV rank, current_iv, rv_20d for the given timestamp.
+        Returns (iv_rank, current_iv, rv_20d).
+        """
+        ...
+
+    def _compute_metrics(
+        self,
+        trades: list[OptionsBacktestTrade],
+        equity_curve: list[dict],
+    ) -> dict:
+        """Compute all performance metrics from trade list and equity curve."""
+        ...
+
+    # --- Internal State ---
+    # self._config: OptionsBacktestConfig
+    # self._decision_function: DecisionFunction
+    # self._model_bundle: ModelBundle
+    # self._kronos_classifier: KronosVolClassifier
+    # self._decision_matrix: OptionsDecisionMatrix
+    # self._bs_engine: BlackScholesEngine
+    # self._position_manager: OptionsPositionManager
+    # self._vix_history: pd.Series
+    # self._kronos_embeddings: torch.Tensor | None
+    # self._risk_free_rate: float
+```
+
+### K. LuxOrchestrator
+
+**File**: `ktrdr_options/orchestrator.py`
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class CycleResult:
+    timestamp: str
+    ktrdr_signal: "KtrdrSignal | None"
+    kronos_regime: "VolRegimeSignal | None"
+    recommendation: "TradeRecommendation | None"
+    actions_taken: list[str]       # ["opened_position", "closed_position:XYZ", ...]
+    errors: list[str]
+    cycle_duration_seconds: float
+
+class LuxOrchestrator:
+    """
+    Main loop for live/paper trading.
+    Runs on schedule, coordinates all components, reports via Telegram.
+    """
+
+    def __init__(
+        self,
+        config_path: str = "ktrdr-options-config.yaml",
+        mode: str = "paper",  # "paper" | "live"
+    ) -> None: ...
+
+    async def run_cycle(self) -> CycleResult:
+        """
+        Execute one analysis + trading cycle.
+
+        Flow:
+        1. Fetch ktrdr signal via KtrdrSignalClient
+        2. Run KronosVolClassifier on recent OHLCV
+        3. Fetch options chain + IV data via OptionsDataProvider
+        4. Aggregate signals via SignalAggregator
+        5. Get recommendation via OpusStrategyAdvisor
+        6. Mark-to-market all open positions
+        7. Check exit conditions on all open positions
+        8. Execute exits if triggered
+        9. Execute new trade if recommended and risk budget available
+        10. Persist state to SQLite
+        11. Send Telegram summary
+
+        Returns:
+            CycleResult with full audit trail.
+        """
+        ...
+
+    async def start(self, interval_minutes: int = 60) -> None:
+        """Start the main loop on the given interval."""
+        ...
+
+    async def stop(self) -> None:
+        """Gracefully stop the main loop."""
+        ...
+
+    async def run_once(self) -> CycleResult:
+        """Run a single cycle (for Telegram on-demand commands)."""
+        ...
+
+    async def _execute_trade(
+        self,
+        recommendation: "TradeRecommendation",
+        decision_input: "DecisionInput",
+    ) -> str:
+        """
+        Submit order to IBKR (paper or live).
+        In live mode, requires Karl's Telegram approval first.
+
+        Returns:
+            Order status string.
+        """
+        ...
+
+    async def _send_telegram_report(
+        self,
+        cycle_result: CycleResult,
+    ) -> None:
+        """Send cycle summary to Karl via Telegram."""
+        ...
+
+    def _check_risk_budget(self) -> float:
+        """
+        Compute remaining risk budget.
+        = account_value * max_risk_pct_total - sum(open_position.max_loss)
+
+        Returns available risk in dollars. 0 = no new trades.
+        """
+        ...
+
+    # --- Internal State ---
+    # self._config: dict (loaded from YAML)
+    # self._ktrdr_client: KtrdrSignalClient
+    # self._kronos_classifier: KronosVolClassifier
+    # self._options_data: OptionsDataProvider
+    # self._aggregator: SignalAggregator
+    # self._opus_advisor: OpusStrategyAdvisor
+    # self._position_manager: OptionsPositionManager
+    # self._mode: str
+    # self._running: bool
+```
+
+---
+
+## 3. Data Model Specifications
+
+### VolRegimeSignal
+
+```python
+@dataclass
+class VolRegimeSignal:
+    regime: str                    # "SELL_VOL" | "BUY_VOL" | "NEUTRAL"
+    confidence: float              # max probability, range 0.0-1.0
+    probabilities: dict[str, float]  # {"SELL_VOL": float, "BUY_VOL": float, "NEUTRAL": float}
+    iv_rank: float                 # current IV rank, range 0-100
+    timestamp: str                 # ISO 8601 datetime
+
+# Example instantiation:
+VolRegimeSignal(
+    regime="SELL_VOL",
+    confidence=0.68,
+    probabilities={"SELL_VOL": 0.68, "BUY_VOL": 0.12, "NEUTRAL": 0.20},
+    iv_rank=78.5,
+    timestamp="2026-04-18T14:30:00Z",
+)
+
+# JSON serialization:
+{
+    "regime": "SELL_VOL",
+    "confidence": 0.68,
+    "probabilities": {"SELL_VOL": 0.68, "BUY_VOL": 0.12, "NEUTRAL": 0.20},
+    "iv_rank": 78.5,
+    "timestamp": "2026-04-18T14:30:00Z"
+}
+```
+
+### KtrdrSignal
+
+```python
+@dataclass
+class KtrdrSignal:
+    signal: str                        # "BUY" | "SELL" | "HOLD"
+    confidence: float                  # max probability, range 0.0-1.0
+    signal_strength: float             # range 0.0-1.0
+    probabilities: dict[str, float]    # {"BUY": float, "HOLD": float, "SELL": float}
+    model_name: str                    # e.g., "trend_tb_lstm_signal_v1"
+    symbol: str                        # e.g., "SPY"
+    timeframe: str                     # e.g., "1h"
+    test_date: str                     # ISO 8601 datetime
+    input_features: dict[str, float]   # fuzzy feature snapshot
+
+# Example:
+KtrdrSignal(
+    signal="BUY",
+    confidence=0.756,
+    signal_strength=0.694,
+    probabilities={"BUY": 0.756, "HOLD": 0.182, "SELL": 0.062},
+    model_name="trend_tb_lstm_signal_v1",
+    symbol="SPY",
+    timeframe="1h",
+    test_date="2026-04-18T14:30:00Z",
+    input_features={"1h_rsi_momentum_oversold": 0.02, "1h_rsi_momentum_overbought": 0.83},
+)
+
+# JSON:
+{
+    "signal": "BUY",
+    "confidence": 0.756,
+    "signal_strength": 0.694,
+    "probabilities": {"BUY": 0.756, "HOLD": 0.182, "SELL": 0.062},
+    "model_name": "trend_tb_lstm_signal_v1",
+    "symbol": "SPY",
+    "timeframe": "1h",
+    "test_date": "2026-04-18T14:30:00Z",
+    "input_features": {"1h_rsi_momentum_oversold": 0.02, "1h_rsi_momentum_overbought": 0.83}
+}
+```
+
+### DecisionInput
+
+```python
+@dataclass
+class DecisionInput:
+    timestamp: str
+    symbol: str
+    current_price: float
+    price_change_1d: float              # % change
+    price_change_5d: float              # % change
+    ktrdr_signal: str                   # "BUY" | "SELL" | "HOLD"
+    ktrdr_confidence: float
+    ktrdr_probabilities: dict[str, float]
+    ktrdr_model_name: str
+    ktrdr_timeframe: str
+    kronos_regime: str                  # "SELL_VOL" | "BUY_VOL" | "NEUTRAL"
+    kronos_confidence: float
+    kronos_probabilities: dict[str, float]
+    iv_rank: float                      # 0-100
+    current_iv: float                   # annualized decimal
+    vix: float
+    rv_20d: float                       # annualized decimal
+    options_chain: dict | None = None   # serialized OptionsChain for live/paper
+    account_value: float = 100_000.0
+    buying_power: float = 100_000.0
+    open_positions_count: int = 0
+    max_risk_per_trade: float = 2_000.0
+    matrix_suggestion: str | None = None
+    matrix_reasoning: str | None = None
+```
+
+### TradeRecommendation
+
+```python
+@dataclass
+class TradeRecommendation:
+    action: str                         # "OPEN" | "CLOSE" | "ADJUST" | "HOLD"
+    structure: str                      # StructureType value
+    legs: list[OptionsLeg]
+    expected_credit: float | None       # positive for credit spreads
+    expected_debit: float | None        # positive for debit spreads
+    max_risk: float                     # dollars
+    max_profit: float                   # dollars
+    breakeven: float | list[float]
+    exit_plan: ExitPlan
+    reasoning: str
+    confidence: str                     # "HIGH" | "MEDIUM" | "LOW"
+    warnings: list[str]
+    source: str                         # "opus" | "matrix"
+
+# Example:
+TradeRecommendation(
+    action="OPEN",
+    structure="bull_put_spread",
+    legs=[
+        OptionsLeg(action="SELL", option_type="PUT", strike=515.0, expiry="2026-05-16", contracts=2, estimated_price=3.30),
+        OptionsLeg(action="BUY", option_type="PUT", strike=510.0, expiry="2026-05-16", contracts=2, estimated_price=1.45),
+    ],
+    expected_credit=1.85,
+    expected_debit=None,
+    max_risk=630.0,
+    max_profit=370.0,
+    breakeven=516.15,
+    exit_plan=ExitPlan(take_profit_pct=50.0, stop_loss_pct=100.0, time_exit_dte=7, signal_reversal_exit=True),
+    reasoning="IV rank at 78.5 with BUY signal. Selling put spread collects elevated premium.",
+    confidence="HIGH",
+    warnings=[],
+    source="opus",
+)
+```
+
+### OptionsLeg
+
+```python
+@dataclass
+class OptionsLeg:
+    leg_id: str = ""                   # UUID, assigned on position creation
+    action: str = ""                   # "BUY" | "SELL"
+    option_type: str = ""              # "CALL" | "PUT"
+    strike: float = 0.0
+    expiry: str = ""                   # ISO 8601 date
+    contracts: int = 0
+    entry_price: float = 0.0           # per-contract at entry
+    estimated_price: float = 0.0       # per-contract estimated (pre-entry)
+    current_price: float = 0.0         # per-contract at current mark
+    current_delta: float = 0.0
+    current_gamma: float = 0.0
+    current_theta: float = 0.0
+    current_vega: float = 0.0
+```
+
+### OptionsPosition
+
+Full definition in Section 2.H above.
+
+### OptionsBacktestTrade
+
+```python
+@dataclass
+class OptionsBacktestTrade:
+    trade_id: str                      # UUID
+    backtest_run_id: str               # FK to backtest_runs
+    symbol: str
+    structure: str                     # StructureType value
+    entry_date: str                    # ISO 8601
+    exit_date: str                     # ISO 8601
+    entry_price: float                 # net credit (positive) or debit (negative)
+    exit_price: float                  # net P&L at exit
+    pnl: float                         # dollar P&L
+    pnl_pct: float                     # P&L as % of max risk
+    max_profit: float
+    max_loss: float
+    exit_reason: str                   # "take_profit" | "stop_loss" | "time_exit" | "signal_reversal" | "expired"
+    ktrdr_signal: str
+    kronos_regime: str
+    iv_rank: float
+    dte_at_entry: int
+    legs: list[dict]                   # serialized leg details
+```
+
+### OptionsBacktestResults
+
+Full definition in Section 2.J above.
+
+---
+
+## 4. Persistence Schema (SQLite)
+
+### Table: positions
+
+```sql
+CREATE TABLE positions (
+    position_id     TEXT PRIMARY KEY,
+    symbol          TEXT NOT NULL,
+    structure       TEXT NOT NULL,     -- StructureType value
+    status          TEXT NOT NULL DEFAULT 'OPEN',  -- OPEN | CLOSED | EXPIRED
+    entry_timestamp TEXT NOT NULL,     -- ISO 8601
+    exit_timestamp  TEXT,
+
+    -- Entry metrics
+    net_entry_price REAL NOT NULL,     -- positive=credit, negative=debit
+    max_profit      REAL NOT NULL,
+    max_loss        REAL NOT NULL,
+    breakeven       TEXT NOT NULL,     -- JSON: float or list[float]
+
+    -- Current state (updated on mark-to-market)
+    current_pnl     REAL DEFAULT 0.0,
+    current_pnl_pct REAL DEFAULT 0.0,
+    dte_remaining   INTEGER DEFAULT 0,
+    net_delta       REAL DEFAULT 0.0,
+    net_gamma       REAL DEFAULT 0.0,
+    net_theta       REAL DEFAULT 0.0,
+    net_vega        REAL DEFAULT 0.0,
+
+    -- Exit plan
+    take_profit_pct REAL DEFAULT 50.0,
+    stop_loss_pct   REAL DEFAULT 100.0,
+    time_exit_dte   INTEGER DEFAULT 7,
+    signal_reversal_exit INTEGER DEFAULT 1,  -- boolean
+
+    -- Exit details
+    exit_reason     TEXT,
+    exit_pnl        REAL DEFAULT 0.0,
+
+    -- Signal context
+    ktrdr_signal    TEXT NOT NULL,
+    kronos_regime   TEXT NOT NULL,
+    iv_rank_at_entry REAL NOT NULL,
+    recommendation_source TEXT NOT NULL,  -- "opus" | "matrix"
+
+    -- Legs (JSON array)
+    legs_json       TEXT NOT NULL,     -- JSON serialized list of OptionsLeg
+
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_positions_status ON positions(status);
+CREATE INDEX idx_positions_symbol ON positions(symbol);
+CREATE INDEX idx_positions_entry_date ON positions(entry_timestamp);
+```
+
+### Table: trades
+
+```sql
+CREATE TABLE trades (
+    trade_id        TEXT PRIMARY KEY,
+    position_id     TEXT NOT NULL REFERENCES positions(position_id),
+    symbol          TEXT NOT NULL,
+    structure       TEXT NOT NULL,
+    entry_date      TEXT NOT NULL,
+    exit_date       TEXT NOT NULL,
+    entry_price     REAL NOT NULL,
+    exit_price      REAL NOT NULL,
+    pnl             REAL NOT NULL,
+    pnl_pct         REAL NOT NULL,
+    max_profit      REAL NOT NULL,
+    max_loss        REAL NOT NULL,
+    exit_reason     TEXT NOT NULL,
+    ktrdr_signal    TEXT NOT NULL,
+    kronos_regime   TEXT NOT NULL,
+    iv_rank         REAL NOT NULL,
+    dte_at_entry    INTEGER NOT NULL,
+    holding_period_days INTEGER NOT NULL,
+    legs_json       TEXT NOT NULL,     -- JSON serialized legs
+    recommendation_source TEXT NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_trades_symbol ON trades(symbol);
+CREATE INDEX idx_trades_exit_date ON trades(exit_date);
+CREATE INDEX idx_trades_structure ON trades(structure);
+CREATE INDEX idx_trades_exit_reason ON trades(exit_reason);
+```
+
+### Table: signals
+
+```sql
+CREATE TABLE signals (
+    signal_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp       TEXT NOT NULL,     -- ISO 8601
+    symbol          TEXT NOT NULL,
+
+    -- ktrdr signal
+    ktrdr_signal    TEXT NOT NULL,     -- BUY | SELL | HOLD
+    ktrdr_confidence REAL NOT NULL,
+    ktrdr_prob_buy  REAL NOT NULL,
+    ktrdr_prob_hold REAL NOT NULL,
+    ktrdr_prob_sell REAL NOT NULL,
+    ktrdr_model     TEXT NOT NULL,
+    ktrdr_timeframe TEXT NOT NULL,
+
+    -- Kronos regime
+    kronos_regime   TEXT NOT NULL,     -- SELL_VOL | BUY_VOL | NEUTRAL
+    kronos_confidence REAL NOT NULL,
+    kronos_prob_sell_vol REAL NOT NULL,
+    kronos_prob_buy_vol  REAL NOT NULL,
+    kronos_prob_neutral  REAL NOT NULL,
+
+    -- Vol context
+    iv_rank         REAL NOT NULL,
+    current_iv      REAL NOT NULL,
+    vix             REAL NOT NULL,
+    rv_20d          REAL NOT NULL,
+
+    -- Decision outcome
+    matrix_suggestion TEXT,
+    action_taken    TEXT,              -- OPEN | HOLD | NO_TRADE
+    position_id     TEXT,              -- FK if position opened
+
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_signals_timestamp ON signals(timestamp);
+CREATE INDEX idx_signals_symbol ON signals(symbol);
+CREATE INDEX idx_signals_ktrdr_signal ON signals(ktrdr_signal);
+CREATE INDEX idx_signals_kronos_regime ON signals(kronos_regime);
+```
+
+### Table: backtest_runs
+
+```sql
+CREATE TABLE backtest_runs (
+    run_id          TEXT PRIMARY KEY,
+    symbol          TEXT NOT NULL,
+    timeframe       TEXT NOT NULL,
+    start_date      TEXT NOT NULL,
+    end_date        TEXT NOT NULL,
+    initial_capital REAL NOT NULL,
+    max_risk_pct    REAL NOT NULL,
+    bid_ask_haircut REAL NOT NULL,
+
+    -- Strategy config
+    strategy_config_path TEXT NOT NULL,
+    model_path      TEXT NOT NULL,
+    kronos_classifier_path TEXT,
+
+    -- Results
+    total_return    REAL,
+    total_return_pct REAL,
+    sharpe_ratio    REAL,
+    max_drawdown_pct REAL,
+    win_rate        REAL,
+    total_trades    INTEGER,
+    winning_trades  INTEGER,
+    losing_trades   INTEGER,
+    profit_factor   REAL,
+
+    -- Options-specific
+    avg_theta_collected REAL,
+    avg_delta_exposure  REAL,
+    gamma_risk_events   INTEGER,
+    structure_breakdown TEXT,  -- JSON dict
+
+    execution_time_seconds REAL,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_backtest_runs_symbol ON backtest_runs(symbol);
+CREATE INDEX idx_backtest_runs_created ON backtest_runs(created_at);
+```
+
+### Table: backtest_trades
+
+```sql
+CREATE TABLE backtest_trades (
+    trade_id        TEXT PRIMARY KEY,
+    run_id          TEXT NOT NULL REFERENCES backtest_runs(run_id),
+    symbol          TEXT NOT NULL,
+    structure       TEXT NOT NULL,
+    entry_date      TEXT NOT NULL,
+    exit_date       TEXT NOT NULL,
+    entry_price     REAL NOT NULL,
+    exit_price      REAL NOT NULL,
+    pnl             REAL NOT NULL,
+    pnl_pct         REAL NOT NULL,
+    max_profit      REAL NOT NULL,
+    max_loss        REAL NOT NULL,
+    exit_reason     TEXT NOT NULL,
+    ktrdr_signal    TEXT NOT NULL,
+    kronos_regime   TEXT NOT NULL,
+    iv_rank         REAL NOT NULL,
+    dte_at_entry    INTEGER NOT NULL,
+    holding_period_days INTEGER NOT NULL,
+    legs_json       TEXT NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_backtest_trades_run ON backtest_trades(run_id);
+CREATE INDEX idx_backtest_trades_structure ON backtest_trades(structure);
+CREATE INDEX idx_backtest_trades_exit_reason ON backtest_trades(exit_reason);
+```
+
+### Table: calibration
+
+```sql
+CREATE TABLE calibration (
+    calibration_id  INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp       TEXT NOT NULL,
+    symbol          TEXT NOT NULL,
+    window_days     INTEGER NOT NULL DEFAULT 30,
+
+    -- ktrdr signal calibration
+    ktrdr_accuracy  REAL,              -- rolling win rate
+    ktrdr_buy_precision REAL,
+    ktrdr_sell_precision REAL,
+    ktrdr_signal_count INTEGER,
+    ktrdr_hold_pct  REAL,              -- % of signals that were HOLD (degeneration check)
+
+    -- Kronos regime calibration
+    kronos_accuracy REAL,              -- did regime prediction match realized outcome?
+    kronos_sell_vol_precision REAL,
+    kronos_buy_vol_precision REAL,
+    kronos_regime_count INTEGER,
+
+    -- Combined system calibration
+    system_win_rate REAL,              -- options trade win rate
+    system_sharpe_rolling REAL,        -- rolling 30-day Sharpe
+    system_avg_pnl_pct REAL,
+    system_trade_count INTEGER,
+
+    -- Structure performance
+    structure_win_rates TEXT,           -- JSON: {"bull_put_spread": 0.65, ...}
+
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_calibration_timestamp ON calibration(timestamp);
+CREATE INDEX idx_calibration_symbol ON calibration(symbol);
+```
+
+---
+
+## 5. Data Flow — Sequence Diagrams
+
+### Flow A: Backtest Cycle (One Bar)
+
+```
+    OptionsBacktestEngine            ktrdr Pipeline           KronosVolClassifier
+            │                              │                          │
+            │  features_t (from cache)     │                          │
+            ├─────────────────────────────>│                          │
+            │                              │                          │
+            │  DecisionFunction.__call__() │                          │
+            │  (features, position, bar)   │                          │
+            │                              │                          │
+            │  TradingDecision             │                          │
+            │  {signal, nn_probabilities}  │                          │
+            │<─────────────────────────────┤                          │
+            │                              │                          │
+            │  kronos_embeddings[bar_idx]                             │
+            ├────────────────────────────────────────────────────────>│
+            │                                                         │
+            │  classifier.forward(embedding)                          │
+            │                                                         │
+            │  VolRegimeSignal                                        │
+            │  {regime, confidence, probabilities}                    │
+            │<────────────────────────────────────────────────────────┤
+            │
+            │                    OptionsDecisionMatrix
+            │                              │
+            │  select(DecisionInput)       │
+            ├─────────────────────────────>│
+            │                              │
+            │  StructureChoice             │
+            │  {structure, target_delta,   │
+            │   target_dte, width}         │
+            │<─────────────────────────────┤
+            │
+            │                    BlackScholesEngine
+            │                              │
+            │  find_strike_by_delta()      │
+            │  price_spread()              │
+            │  apply_haircut()             │
+            ├─────────────────────────────>│
+            │                              │
+            │  {strikes, entry_price,      │
+            │   max_profit, max_loss,      │
+            │   greeks}                    │
+            │<─────────────────────────────┤
+            │
+            │                    OptionsPositionManager
+            │                              │
+            │  open_position() or          │
+            │  mark_to_market() +          │
+            │  check_exit_conditions()     │
+            ├─────────────────────────────>│
+            │                              │
+            │  OptionsPosition             │
+            │<─────────────────────────────┤
+            │
+            │                    SQLite
+            │                       │
+            │  INSERT/UPDATE         │
+            ├──────────────────────>│
+            │                       │
+            v                       v
+```
+
+### Flow B: Live/Paper Analysis Cycle (Lux Triggered)
+
+```
+    LuxOrchestrator    KtrdrSignalClient     ktrdr REST API    KronosVolClassifier
+          │                    │                    │                    │
+          │ predict(model,     │                    │                    │
+          │ symbol, tf)        │                    │                    │
+          ├───────────────────>│                    │                    │
+          │                    │ POST /api/v1/      │                    │
+          │                    │ models/predict     │                    │
+          │                    ├───────────────────>│                    │
+          │                    │                    │                    │
+          │                    │ PredictionResponse │                    │
+          │                    │ + probabilities    │                    │
+          │                    │<───────────────────┤                    │
+          │ KtrdrSignal        │                    │                    │
+          │<───────────────────┤                    │                    │
+          │                                                             │
+          │ predict(ohlcv, iv_rank)                                     │
+          ├────────────────────────────────────────────────────────────>│
+          │                                                             │
+          │ VolRegimeSignal                                             │
+          │<────────────────────────────────────────────────────────────┤
+          │
+          │     OptionsDataProvider
+          │            │
+          │ get_options_chain()
+          │ get_iv_data()
+          ├───────────>│──────> yfinance / IBKR MCP
+          │            │<────── OptionsChain, IVData
+          │<───────────┤
+          │
+          │     SignalAggregator
+          │            │
+          │ aggregate()│
+          ├───────────>│
+          │ DecisionInput
+          │<───────────┤
+          │
+          │     OpusStrategyAdvisor              Anthropic API
+          │            │                              │
+          │ advise()   │                              │
+          ├───────────>│  POST /v1/messages            │
+          │            │  (structured JSON prompt)     │
+          │            ├─────────────────────────────>│
+          │            │                              │
+          │            │  JSON response               │
+          │            │  (structure, legs, reasoning) │
+          │            │<─────────────────────────────┤
+          │            │                              │
+          │            │ validate(recommendation)     │
+          │ TradeRecommendation                       │
+          │<───────────┤
+          │
+          │     OptionsPositionManager     IBKR MCP        Telegram
+          │            │                      │                │
+          │ open_position()                   │                │
+          ├───────────>│                      │                │
+          │            │                      │                │
+          │ _execute_trade()                  │                │
+          ├──────────────────────────────────>│                │
+          │            │  order confirmation  │                │
+          │<─────────────────────────────────┤                │
+          │                                                    │
+          │ _send_telegram_report()                            │
+          ├───────────────────────────────────────────────────>│
+          │                                                    │
+          v                                                    v
+```
+
+### Flow C: Error Handling — ktrdr API Unavailable
+
+```
+    LuxOrchestrator    KtrdrSignalClient         ktrdr REST API
+          │                    │                        │
+          │ predict()          │                        │
+          ├───────────────────>│                        │
+          │                    │ POST /predict          │
+          │                    ├───────────────────────>│
+          │                    │                        │ CONNECTION REFUSED
+          │                    │<──────────────────────X│
+          │                    │                        │
+          │                    │ retry 1 (backoff 2s)   │
+          │                    ├───────────────────────>│
+          │                    │                        │ TIMEOUT
+          │                    │<──────────────────────X│
+          │                    │                        │
+          │                    │ retry 2 (backoff 4s)   │
+          │                    ├───────────────────────>│
+          │                    │                        │ TIMEOUT
+          │                    │<──────────────────────X│
+          │                    │                        │
+          │ KtrdrAPIError      │                        │
+          │<───────────────────┤                        │
+          │                                             │
+          │ DECISION: HOLD all positions                │
+          │ (no new trades opened)                      │
+          │                                             │
+          │     SQLite                   Telegram       │
+          │        │                        │           │
+          │ log signal (error)              │           │
+          ├───────>│                        │           │
+          │                                 │           │
+          │ send alert:                     │           │
+          │ "ktrdr API unavailable,         │           │
+          │  holding all positions"         │           │
+          ├────────────────────────────────>│           │
+          │                                 │           │
+          v                                 v           v
+```
+
+### Flow D: Error Handling — Opus 4.7 Unavailable
+
+```
+    OpusStrategyAdvisor          Anthropic API       OptionsDecisionMatrix
+          │                           │                       │
+          │ POST /v1/messages         │                       │
+          ├──────────────────────────>│                       │
+          │                           │ 529 OVERLOADED        │
+          │<─────────────────────────X│                       │
+          │                           │                       │
+          │ retry 1                   │                       │
+          ├──────────────────────────>│                       │
+          │                           │ TIMEOUT (60s)         │
+          │<─────────────────────────X│                       │
+          │                           │                       │
+          │ FALLBACK to matrix        │                       │
+          │                           │                       │
+          │ select(decision_input)                            │
+          ├──────────────────────────────────────────────────>│
+          │                                                   │
+          │ StructureChoice                                   │
+          │<──────────────────────────────────────────────────┤
+          │                                                   │
+          │ Build TradeRecommendation                          │
+          │ source="matrix"                                   │
+          │ reasoning="Opus unavailable. Fallback to          │
+          │            deterministic matrix."                  │
+          │ warnings=["opus_fallback"]                         │
+          │                                                   │
+          │ LOG: "Opus 4.7 unavailable, used matrix fallback" │
+          │                                                   │
+          │ return TradeRecommendation                         │
+          v                                                   v
+```
+
+---
+
+## 6. State Management
+
+### In-Memory State
+
+| Component | State Held | Lifecycle | Reset Behavior |
+|-----------|-----------|-----------|---------------|
+| `KronosVolClassifier` | `_kronos_model` (frozen weights), `_tokenizer`, `_classifier` (linear head) | Loaded once at startup | Never reset during session. Reload requires restart. |
+| `KtrdrSignalClient` | `_client` (httpx.AsyncClient) | Created at init, reused | Connection pool auto-managed by httpx. |
+| `OptionsDataProvider` | `_vix_cache` (pd.Series), `_rate_cache` (dict) | Populated on first call, refreshed daily | Invalidated when date changes. |
+| `SignalAggregator` | `_decision_matrix` (reference) | Stateless beyond config | N/A — no mutable state. |
+| `OpusStrategyAdvisor` | `_client` (anthropic.AsyncAnthropic) | Created at init | N/A — stateless per call. |
+| `OptionsPositionManager` | `_open_positions` (list) | Loaded from SQLite at init, updated on open/close | Reloaded from SQLite on restart. |
+| `OptionsBacktestEngine` | `_kronos_embeddings` (torch.Tensor), `_vix_history` (pd.Series), feature cache | Loaded once per run | Garbage collected after run completes. |
+| `LuxOrchestrator` | `_running` (bool), component references | Init to stop | `_running` set False on stop(). |
+
+### Persistent State (SQLite)
+
+| Data | Written When | Read When |
+|------|-------------|----------|
+| `positions` table | On `open_position()`, updated on `mark_to_market()` and `close_position()` | On startup (reload open positions), on `get_open_positions()`, `get_position_history()` |
+| `trades` table | On `close_position()` | Performance analysis, calibration computation |
+| `signals` table | End of each cycle (live/paper) | Calibration, signal distribution monitoring |
+| `backtest_runs` table | After backtest completes | Backtest comparison |
+| `backtest_trades` table | During backtest, per trade close | Backtest analysis |
+| `calibration` table | Periodically (e.g., daily) by LuxOrchestrator | Monitoring, alerting, model degradation detection |
+
+### Ephemeral State (Per-Cycle, Discarded)
+
+| Data | Component | Scope |
+|------|-----------|-------|
+| `KtrdrSignal` (current) | `LuxOrchestrator.run_cycle()` | One cycle |
+| `VolRegimeSignal` (current) | `LuxOrchestrator.run_cycle()` | One cycle |
+| `OptionsChain` (current snapshot) | `LuxOrchestrator.run_cycle()` | One cycle |
+| `DecisionInput` | `SignalAggregator.aggregate()` | One cycle |
+| `TradeRecommendation` | `OpusStrategyAdvisor.advise()` | One cycle |
+| `CycleResult` | `LuxOrchestrator.run_cycle()` | One cycle (logged, then GC'd) |
+| Per-bar ktrdr signal (backtest) | `OptionsBacktestEngine.run()` | One bar iteration |
+
+### Cached State (Disk)
+
+| Cache | Format | Location | Invalidation |
+|-------|--------|----------|-------------|
+| Kronos embeddings | `.pt` (PyTorch tensor) | `cache/kronos/{symbol}_{timeframe}_embeddings.pt` | Re-compute when OHLCV data range changes or Kronos model version changes |
+| ktrdr feature cache | In-memory dict (within BacktestingEngine) | Not persisted to disk — computed fresh per backtest run | Per run |
+| VIX history | CSV | `cache/vix_daily.csv` | Re-download when >1 day stale |
+| Risk-free rate | JSON | `cache/risk_free_rate.json` | Re-fetch when >1 day stale |
+| Classifier head weights | `.pt` | `models/kronos_classifier/{symbol}_head.pt` + `config.json` | Retrain when AUC degrades or data expands |
+
+### State Lifecycle Summary
+
+```
+STARTUP:
+  1. Load config from YAML
+  2. Initialize KronosVolClassifier (load model + classifier weights)
+  3. Initialize KtrdrSignalClient (create HTTP client)
+  4. Initialize OptionsDataProvider
+  5. Initialize OptionsPositionManager (connect SQLite, load open positions)
+  6. Initialize OpusStrategyAdvisor (create Anthropic client)
+  7. Initialize SignalAggregator + OptionsDecisionMatrix
+
+PER CYCLE (live/paper):
+  1. Create ephemeral: KtrdrSignal, VolRegimeSignal, IVData, OptionsChain
+  2. Create ephemeral: DecisionInput, TradeRecommendation
+  3. Update persistent: positions (mark-to-market), trades (if closed)
+  4. Create persistent: signals (log entry)
+  5. Discard all ephemeral state
+
+PER BACKTEST RUN:
+  1. Load cached: Kronos embeddings (or compute + cache)
+  2. Load cached: VIX history (or download + cache)
+  3. Per bar: compute ephemeral signal state, update in-memory positions
+  4. Write persistent: backtest_runs, backtest_trades (after run completes)
+  5. Discard: all in-memory state
+
+SHUTDOWN:
+  1. Close HTTP clients
+  2. Close SQLite connections
+  3. GC all in-memory state
+```
+
+---
+
+## 7. API Contract — ktrdr Endpoint Extension
+
+### Current PredictionResponse Schema
+
+**Source**: `ktrdr/api/endpoints/models.py`, lines 194-229
+
+```python
+class Prediction(BaseModel):
+    signal: str              # "BUY" | "SELL" | "HOLD"
+    confidence: float        # max probability
+    signal_strength: float   # 0.0-1.0
+
+class PredictionResponse(BaseModel):
+    success: bool
+    model_name: str
+    symbol: str
+    test_date: str
+    prediction: Prediction
+    input_features: dict[str, float]
+```
+
+Current response JSON:
+```json
+{
+    "success": true,
+    "model_name": "trend_tb_lstm_signal_v1",
+    "symbol": "SPY",
+    "test_date": "2026-04-18T14:30:00",
+    "prediction": {
+        "signal": "BUY",
+        "confidence": 0.756,
+        "signal_strength": 0.694
+    },
+    "input_features": {"1h_rsi_momentum_oversold": 0.02, ...}
+}
+```
+
+### Proposed Extension
+
+```python
+class Prediction(BaseModel):
+    signal: str
+    confidence: float
+    signal_strength: float
+    probabilities: dict[str, float] | None = None  # NEW: optional field
+
+class PredictionResponse(BaseModel):
+    success: bool
+    model_name: str
+    symbol: str
+    test_date: str
+    prediction: Prediction
+    input_features: dict[str, float]
+```
+
+Extended response JSON:
+```json
+{
+    "success": true,
+    "model_name": "trend_tb_lstm_signal_v1",
+    "symbol": "SPY",
+    "test_date": "2026-04-18T14:30:00",
+    "prediction": {
+        "signal": "BUY",
+        "confidence": 0.756,
+        "signal_strength": 0.694,
+        "probabilities": {"BUY": 0.756, "HOLD": 0.182, "SELL": 0.062}
+    },
+    "input_features": {"1h_rsi_momentum_oversold": 0.02, ...}
+}
+```
+
+### Backward Compatibility
+
+- The `probabilities` field is **optional** (`None` default). Existing clients that do not expect it will ignore the extra field (standard JSON parsing behavior).
+- No existing fields are modified or removed.
+- The field is populated from `TradingDecision.reasoning["nn_probabilities"]` which already exists in the internal pipeline (see `ktrdr/decision/base.py:26`, reasoning dict).
+- **Code change**: In the prediction endpoint handler, after obtaining `TradingDecision`, extract `reasoning.get("nn_probabilities")` and pass to `Prediction(probabilities=...)`.
+- Estimated change: ~5-10 lines in `ktrdr/api/endpoints/models.py`.
+
+---
+
+## 8. Configuration Schema
+
+```yaml
+# ktrdr-options-config.yaml
+# Complete configuration for the ktrdr Autonomous Options Trading System
+
+# --- ktrdr Signal Source ---
+ktrdr:
+  base_url: "http://localhost:8000"      # ktrdr REST API base URL
+  model_name: "trend_tb_lstm_signal_v1"  # trained model to use
+  symbol: "SPY"                          # underlying ticker
+  timeframe: "1h"                        # bar timeframe for signals
+  timeout_seconds: 30.0                  # HTTP request timeout
+  max_retries: 3                         # retries on failure
+  retry_backoff_base: 2.0                # exponential backoff base (seconds)
+  stale_bar_threshold: 2                 # alert if response is >N bars stale
+
+# --- Kronos Vol Regime Classifier ---
+kronos:
+  model: "NeoQuasar/Kronos-mini"         # HuggingFace model name
+  tokenizer: "NeoQuasar/Kronos-Tokenizer-2k"  # tokenizer for mini
+  classifier_weights_path: "models/kronos_classifier/SPY_head.pt"
+  device: "cpu"                          # "cpu" | "cuda"
+  embedding_dim: 256                     # must match model (256 for mini)
+  pooling: "last"                        # "last" | "mean" [VALIDATE EMPIRICALLY]
+  context_window: 512                    # bars to feed Kronos
+  embeddings_cache_dir: "cache/kronos"   # pre-computed embeddings
+
+  # Classifier training config (used during Phase 1)
+  training:
+    iv_rank_high_pct: 70                 # percentile for SELL_VOL label
+    iv_rank_low_pct: 30                  # percentile for BUY_VOL label
+    rv_discount: 0.85                    # RV < IV * discount = SELL_VOL
+    rv_premium: 1.15                     # RV > IV * premium = BUY_VOL
+    forward_rv_window: 20               # days for forward realized vol
+    train_epochs: 100
+    train_lr: 0.001
+    class_weights: [1.0, 2.0, 2.5]      # [NEUTRAL, SELL_VOL, BUY_VOL] — upweight rare classes
+
+  # Fallback: if Kronos model load fails, use IV rank heuristic
+  fallback_iv_rank_high: 70              # IV rank > this = SELL_VOL
+  fallback_iv_rank_low: 30              # IV rank < this = BUY_VOL
+
+# --- Options Data ---
+options_data:
+  mode: "backtest"                       # "backtest" | "paper" | "live"
+  vix_data_path: null                    # optional cached VIX CSV
+  cache_dir: "cache"
+  iv_rank_lookback_days: 252             # trading days for IV rank computation
+
+  # For paper/live mode
+  ibkr:
+    host: "localhost"
+    port: 7497                           # 7497=paper, 7496=live
+    client_id: 1
+
+# --- Opus 4.7 Strategy Advisor ---
+opus:
+  enabled: true                          # set false to use matrix only
+  model: "claude-opus-4-7-20260401"
+  timeout_seconds: 60.0
+  max_retries: 2
+  # API key sourced from ANTHROPIC_API_KEY env var
+
+# --- Decision Matrix ---
+decision_matrix:
+  # Confidence gates
+  min_ktrdr_confidence: 0.45             # minimum for any directional trade
+  min_ktrdr_confidence_naked: 0.65       # minimum for naked long options
+  min_kronos_confidence_vol: 0.70        # minimum for vol-specific structures (condor, straddle)
+  min_kronos_confidence_other: 0.50      # minimum for all other structures
+
+# --- Risk Management ---
+risk:
+  max_risk_per_trade_pct: 0.02           # 2% of account value per trade
+  max_total_risk_pct: 0.10               # 10% of account total open risk
+  max_positions: 5                       # max simultaneous open positions
+  initial_capital: 100000.0
+
+  # Position sizing from probability spread
+  sizing:
+    low_spread_threshold: 0.10           # probability_spread < this -> 0.5x
+    medium_spread_threshold: 0.25        # probability_spread < this -> 0.75x
+    low_multiplier: 0.5
+    medium_multiplier: 0.75
+    high_multiplier: 1.0
+
+# --- Structure Parameters ---
+structures:
+  bull_put_spread:
+    dte_min: 30
+    dte_max: 45
+    short_delta: 0.30                    # target delta for short leg
+    width_strikes: 1                     # width in strike increments
+  iron_condor:
+    dte_min: 30
+    dte_max: 45
+    short_delta: 0.16                    # each side
+    width_strikes: 1
+  bull_call_spread:
+    dte_min: 21
+    dte_max: 35
+    long_delta: 0.45
+    width_strikes: 2
+  bear_call_spread:
+    dte_min: 30
+    dte_max: 45
+    short_delta: 0.30
+    width_strikes: 1
+  long_call:
+    dte_min: 14
+    dte_max: 30
+    long_delta: 0.40
+  long_straddle:
+    dte_min: 14
+    dte_max: 30
+    # ATM by definition
+  bear_put_spread:
+    dte_min: 21
+    dte_max: 35
+    long_delta: 0.45
+    width_strikes: 2
+  long_put:
+    dte_min: 14
+    dte_max: 30
+    long_delta: 0.40
+
+# --- Exit Rules ---
+exits:
+  take_profit_pct: 50.0                  # close at 50% of max profit
+  stop_loss_pct: 100.0                   # close at 100% of max loss
+  time_exit_dte: 7                       # close when DTE < 7
+  signal_reversal_exit: true             # close when ktrdr signal reverses
+  # Dividend protection
+  exclude_near_ex_dividend_days: 5       # skip entries within N days of ex-date
+
+# --- Backtest ---
+backtest:
+  bid_ask_haircut: 0.10                  # 10% flat haircut on B-S prices
+  risk_free_rate_override: null          # null = fetch from FRED; set float to override
+  strike_step: 1.0                       # SPY strike increment ($1)
+  db_path: "backtest_results.db"
+
+# --- Persistence ---
+persistence:
+  db_path: "ktrdr_options.db"            # SQLite database for live/paper
+
+# --- Scheduling ---
+schedule:
+  interval_minutes: 60                   # analysis cycle frequency
+  trading_hours_only: true               # skip cycles outside market hours
+  market_open: "09:30"                   # ET
+  market_close: "16:00"                  # ET
+  timezone: "US/Eastern"
+
+# --- Notifications ---
+notifications:
+  telegram:
+    enabled: true
+    # Bot token and chat ID sourced from env vars:
+    # TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID
+    notify_on:
+      - trade_opened
+      - trade_closed
+      - error
+      - daily_summary
+      - calibration_alert
+
+# --- Logging ---
+logging:
+  level: "INFO"                          # DEBUG | INFO | WARNING | ERROR
+  file: "logs/ktrdr_options.log"
+  rotation: "10 MB"
+  retention: 30                          # days
+```
+
+---
+
+## 9. Error Handling Matrix
+
+| Component | Failure Mode | Detection | Impact | Mitigation | Recovery |
+|-----------|-------------|-----------|--------|------------|---------|
+| **KtrdrSignalClient** | API unreachable (connection refused, DNS failure) | `httpx.ConnectError` after 3 retries with exponential backoff (2s, 4s, 8s) | No directional signal for this cycle | HOLD all positions. No new trades. Log error. | Next cycle retries normally. Alert via Telegram if 3+ consecutive failures. |
+| **KtrdrSignalClient** | API returns error (500, malformed response) | HTTP status != 200 or JSON parse failure | No directional signal | Same as above: HOLD, no new trades. | Auto-recovers on next successful call. |
+| **KtrdrSignalClient** | Stale data (response test_date > 2 bars behind) | Compare `test_date` in response to current time | Signal based on outdated market data | Log `KtrdrStaleDataError`. Treat as HOLD. Telegram alert. | Investigate ktrdr data pipeline. May need `ktrdr data load` to refresh OHLCV cache. |
+| **KronosVolClassifier** | Model weights not found / corrupted | `FileNotFoundError` or `RuntimeError` on `load_model()` | No vol regime signal | Fall back to IV rank heuristic: IV rank > 70 = SELL_VOL, < 30 = BUY_VOL, else NEUTRAL. Log warning. | Re-download weights from HuggingFace. Restart. |
+| **KronosVolClassifier** | Forward pass error (OOM, NaN output) | `RuntimeError` or NaN check on output tensor | No vol regime signal | Fall back to IV rank heuristic for this cycle. | Typically transient. If persistent, reduce context_window or check input data quality. |
+| **KronosVolClassifier** | Classifier head not trained (no weights file) | `classifier_weights_path` is None or file missing | Raw Kronos embedding available but no classification | Use IV rank heuristic fallback. This is expected before Phase 1 training completes. | Train classifier head (Phase 1 deliverable). |
+| **OptionsDataProvider** | yfinance rate limit or outage | `HTTPError` or empty response | No IV data, no options chain | For IV: use last cached VIX value with staleness warning. For chain: cannot open new positions (HOLD). | yfinance rate limits are transient. Retry next cycle. Cache VIX history locally to reduce API calls. |
+| **OptionsDataProvider** | IBKR MCP disconnected (paper/live) | MCP tool returns error | No real options chain data | Cannot open new positions. Mark-to-market uses last known chain. | Reconnect IBKR. Check IB Gateway is running. |
+| **OpusStrategyAdvisor** | API unavailable (outage, rate limit) | `anthropic.APIConnectionError` or 529 status after 2 retries | No Opus reasoning for this cycle | Fall back to OptionsDecisionMatrix. TradeRecommendation.source = "matrix". Log fallback. | Auto-recovers. If persistent, set `opus.enabled: false` in config. |
+| **OpusStrategyAdvisor** | Malformed JSON response | JSON parse error or missing required fields | Cannot use Opus recommendation | Retry once with explicit "respond in valid JSON" constraint. Then fall back to matrix. | Usually transient. If model consistently fails, update prompt. |
+| **OpusStrategyAdvisor** | Recommendation violates risk limits | Validation detects max_risk > budget or structure not in allowed list | Would create unsafe position | Reject recommendation. Retry with explicit constraint. After 2 retries, use matrix fallback. | Log the specific violation for prompt tuning. |
+| **OpusStrategyAdvisor** | Timeout (>60s) | `asyncio.TimeoutError` | Blocks cycle | Cancel request, use matrix fallback. | Transient. Consider increasing timeout if Opus consistently uses extended thinking. |
+| **OptionsPositionManager** | SQLite write failure (disk full, corruption) | `sqlite3.OperationalError` | Cannot persist position state | Log CRITICAL error. Continue with in-memory state only. Telegram alert. | Free disk space. If corruption: restore from last backup. In-memory positions survive until restart. |
+| **OptionsPositionManager** | Position mark-to-market fails (NaN Greeks) | NaN check on BlackScholesEngine output | Position shows invalid current values | Use last valid mark. Log warning. | Usually caused by T -> 0 (near expiry). Force-close positions at time_exit_dte threshold. |
+| **BlackScholesEngine** | Invalid inputs (negative vol, T=0, S=0) | Input validation checks | Cannot price options | Return None / raise `ValueError`. Caller skips this trade. | Fix upstream data quality issue. |
+| **LuxOrchestrator** | Unhandled exception in cycle | Top-level try/except in `run_cycle()` | One cycle fails | Log full traceback. Send Telegram error alert. Continue to next cycle. | Investigate logs. Fix bug. System auto-continues. |
+| **LuxOrchestrator** | Multiple consecutive cycle failures (>5) | Counter of consecutive errors | System may be fundamentally broken | Stop opening new positions. Continue monitoring/exiting existing positions. Telegram CRITICAL alert. | Manual investigation required. |
+
+---
+
+## 10. Dependency Map
+
+### Hard Dependencies (System Cannot Function Without)
+
+| Dependency | Version | Purpose |
+|-----------|---------|---------|
+| `python` | >= 3.12 | Runtime |
+| `torch` | >= 2.0.0 | Kronos model inference, classifier training |
+| `numpy` | >= 1.24 | Numerical computation (Black-Scholes, Greeks) |
+| `scipy` | >= 1.10 | `scipy.stats.norm` for Black-Scholes N(d) |
+| `pandas` | >= 2.0 | Data manipulation, time series |
+| `httpx` | >= 0.24 | Async HTTP client for ktrdr REST API |
+| `anthropic` | >= 0.40 | Anthropic API client for Opus 4.7 |
+| ktrdr REST API | (local service) | Directional trading signal source |
+| SQLite | (stdlib) | Persistence (positions, trades, signals) |
+
+### Hard Dependencies — Kronos-Specific
+
+| Dependency | Version | Purpose |
+|-----------|---------|---------|
+| `einops` | == 0.8.1 | Required by Kronos model code |
+| `huggingface_hub` | >= 0.20 | Download Kronos model weights |
+| `safetensors` | >= 0.4 | Load Kronos model weights |
+| Kronos model weights | `NeoQuasar/Kronos-mini` | Frozen transformer for embeddings |
+| Kronos tokenizer | `NeoQuasar/Kronos-Tokenizer-2k` | OHLCV tokenization |
+
+### Hard Dependencies — ktrdr Library (Backtest Only)
+
+| Dependency | Import Path | Purpose |
+|-----------|-------------|---------|
+| `DecisionFunction` | `ktrdr.backtesting.decision_function` | Generate directional signals per bar |
+| `ModelBundle` | `ktrdr.backtesting.model_bundle` | Load trained ktrdr models |
+| `IndicatorEngine` | `ktrdr.indicators.indicator_engine` | Compute technical indicators |
+| `FuzzyEngine` | `ktrdr.fuzzy.engine` | Convert indicators to fuzzy memberships |
+| `FuzzyNeuralProcessor` | `ktrdr.training.fuzzy_neural_processor` | Assemble feature tensors |
+| `FeatureResolver` | `ktrdr.config.feature_resolver` | Canonical feature ordering |
+| `LocalDataLoader` | `ktrdr.data.local_data_loader` | Load OHLCV from CSV cache |
+
+### Soft Dependencies (Graceful Degradation)
+
+| Dependency | Purpose | Degradation Behavior |
+|-----------|---------|---------------------|
+| `yfinance` | VIX history, current options chains, underlying prices | Backtest: use cached VIX CSV. Live: fall back to IBKR data only. |
+| `pandas_datareader` or FRED API | Risk-free rate | Use hardcoded rate (e.g., 0.05) or config override |
+| Anthropic API (Opus 4.7) | Strategy reasoning | Fall back to OptionsDecisionMatrix (deterministic) |
+| IBKR MCP (paper/live) | Order execution, real options chain | Cannot execute trades. System operates in analysis-only mode. |
+| Telegram Bot API | Notifications to Karl | Log locally. No notifications. System continues trading. |
+| Kronos model | Vol regime classification | Fall back to IV rank heuristic (>70 = SELL_VOL, <30 = BUY_VOL, else NEUTRAL) |
+
+### External Services
+
+| Service | Protocol | Usage Context | Latency Tolerance |
+|---------|----------|--------------|-------------------|
+| ktrdr REST API | HTTP (localhost) | Every cycle (live/paper) | < 30s (including retries) |
+| Anthropic API | HTTPS (remote) | Every cycle (live/paper, if Opus enabled) | < 60s |
+| IBKR MCP | Local MCP protocol | Paper/live trading | < 10s per order |
+| yfinance | HTTPS (remote) | Options chain + VIX fetch | < 30s |
+| FRED API | HTTPS (remote) | Risk-free rate (daily) | < 10s |
+| Telegram Bot API | HTTPS (remote) | Notifications | < 5s (non-blocking) |
+| HuggingFace Hub | HTTPS (remote) | Model weight download (one-time) | Minutes (first run only) |
+
+---
+
+## Appendix: Open Decisions and Empirical Validation Items
+
+### [DECISION NEEDED]
+
+1. **Which symbols to start with?** SPY recommended first. Second symbol TBD by Karl.
+2. **Budget for historical options data?** $0 (B-S reconstruction), ~$200 (OptionsDX), or $1000+ (CBOE).
+3. **ktrdr API extension**: Extend `/predict` to return `probabilities` field (~10 lines). Recommended over library-direct approach.
+4. **Live trading approval gate**: All live trades require Karl's Telegram approval initially?
+5. **IBKR MCP options capabilities**: Does the existing IBKR integration support multi-leg options orders? Needs investigation.
+6. **Max risk per trade**: 2% default. Karl may adjust.
+
+### [VALIDATE EMPIRICALLY]
+
+1. Kronos embedding AUC > 0.60 for vol regime classification (Phase 1 gate).
+2. Mean pool vs last hidden state for Kronos embeddings.
+3. Kronos-mini (256d) vs Kronos-small (512d) for classification quality.
+4. Bid/ask haircut calibration (10% starting guess).
+5. Optimal DTE per structure type (test 14, 21, 30, 45).
+6. Label thresholds for vol regime (70/30 percentile, 0.85/1.15 multipliers).
+7. Exit timing parameters (take profit at 40/50/60%, stop loss at 75/100%).
+8. Kronos CPU inference latency on Karl's Docker stack.
+9. Forward RV window length (10, 15, 20, 30 days).

--- a/docs/designs/autonomous-options-trading/DESIGN.md
+++ b/docs/designs/autonomous-options-trading/DESIGN.md
@@ -2,7 +2,7 @@
 
 > **Author**: Claude (Opus 4.6), commissioned by Karl Piteira
 > **Date**: 2026-04-18
-> **Status**: Draft — awaiting Karl's review before architecture phase
+> **Status**: Draft v3 — fixes applied for IV metric consistency, backtest/live validation gap, SPY model prerequisite, label frequency calibration
 > **Grounded in**: ktrdr codebase analysis (`KTRDR_REALITY_MAP.md`), Kronos integration spec (`spec.md`)
 
 ---
@@ -59,7 +59,7 @@ Karl has a working directional trading system (ktrdr) with a Sharpe ratio ceilin
              v                v                v
     +--------------------------------------------------+
     |           Signal Aggregation Layer                |
-    |  ktrdr signal + Kronos regime + IV rank/data     |
+    |  ktrdr signal + Kronos regime + IV percentile    |
     +------------------------+-------------------------+
                              |
                              v
@@ -90,7 +90,7 @@ Karl has a working directional trading system (ktrdr) with a Sharpe ratio ceilin
 | **Lux** | Orchestrates the entire flow: polls ktrdr, runs Kronos, calls Opus 4.7, manages positions, reports via Telegram |
 | **ktrdr REST API** | Produces directional signal (BUY/SELL/HOLD + probability distribution) from existing trained models |
 | **Kronos Vol Regime Classifier** | Classifies current market as SELL_VOL / BUY_VOL / NEUTRAL based on frozen Kronos embeddings + trained linear head |
-| **Options Data Provider** | Supplies IV rank, options chain data, and historical IV for backtesting |
+| **Options Data Provider** | Supplies IV percentile, options chain data, and historical IV for backtesting |
 | **Signal Aggregation** | Combines ktrdr directional signal, Kronos vol regime, and IV context into a structured decision input |
 | **Opus 4.7 Reasoning** | Selects optimal options structure, strikes, expiry, and position size given the aggregated signal |
 | **Position Manager** | Tracks open options positions, monitors Greeks, triggers exit conditions |
@@ -104,7 +104,7 @@ Karl has a working directional trading system (ktrdr) with a Sharpe ratio ceilin
 
 3. **Fetch Kronos vol regime**: Lux calls the Kronos classifier (Python function, not REST — runs in Lux's process or via subprocess). Inputs recent OHLCV bars. Receives `{regime: SELL_VOL|BUY_VOL|NEUTRAL, confidence: float}`.
 
-4. **Fetch options context**: Lux retrieves current IV rank (from VIX for indices, or from options chain data for single names) and the relevant options chain (strikes, expiries, bid/ask).
+4. **Fetch options context**: Lux retrieves current IV percentile (from VIX for indices, or from options chain data for single names) and the relevant options chain (strikes, expiries, bid/ask).
 
 5. **Aggregate and call Opus 4.7**: Lux constructs a structured JSON prompt containing the ktrdr signal, Kronos regime, IV data, and options chain. Sends to Opus 4.7 via Anthropic API with extended thinking enabled.
 
@@ -227,17 +227,20 @@ The classifier is trained on historical data where the label is derived from the
 ```
 Label construction:
   1. For each bar t, compute:
-     - IV_rank_t = percentile rank of current IV over trailing 252 trading days
+     - IV_percentile_t = percentile rank of current IV over trailing 252 trading days
+       (i.e., the fraction of days in the lookback window where IV was lower than today's IV)
      - RV_forward = realized volatility over the next N trading days (N = target holding period, e.g., 20 days)
      - IV_t = current implied volatility (from VIX for indices, or from ATM option IV for single names)
   
   2. Assign label:
-     - SELL_VOL:  IV_rank_t > 70th percentile AND RV_forward < IV_t * 0.85
-                  (IV is high AND realized vol came in lower — selling premium was correct)
-     - BUY_VOL:   IV_rank_t < 30th percentile AND RV_forward > IV_t * 1.15
-                  (IV is low AND realized vol expanded — buying options was correct)
+     - SELL_VOL:  IV_percentile_t > 70 AND RV_forward < IV_t * 0.85
+                  (IV is high relative to its history AND realized vol came in lower — selling premium was correct)
+     - BUY_VOL:   IV_percentile_t < 30 AND RV_forward > IV_t * 1.15
+                  (IV is low relative to its history AND realized vol expanded — buying options was correct)
      - NEUTRAL:   everything else
 ```
+
+**Why IV Percentile instead of IV Rank**: This system uses **IV Percentile** (the fraction of trailing days where IV was lower than today) rather than **IV Rank** (min-max normalization: `(current - low) / (high - low)`). IV Percentile is more statistically robust because it is not distorted by outlier spikes. Example: if VIX sat between 15-17 for most of the year but spiked to 35 briefly, IV Rank of 22 would be only 35% (`(22-15)/(35-15)`), while IV Percentile of 22 would correctly reflect that 22 is higher than the vast majority of observed days (likely 90%+). For options structure selection, we care about how unusual today's IV is relative to the distribution of recent IV — that is what IV Percentile measures. The 70/30 percentile thresholds are calibrated to this metric: "IV is higher than 70% of recent days" is a meaningful statement regardless of whether extreme outliers exist in the lookback window.
 
 **[ASSUMPTION]**: The 70th/30th percentile thresholds and the 0.85/1.15 multipliers are starting points. These should be tuned during Phase 1 validation. The label construction must avoid look-ahead bias — labels are based on *future* realized vol but the *features* (Kronos embeddings) use only past bars.
 
@@ -257,18 +260,18 @@ class VolRegimeSignal:
     regime: str            # "SELL_VOL" | "BUY_VOL" | "NEUTRAL"
     confidence: float      # max probability (0.0-1.0)
     probabilities: dict    # {"SELL_VOL": float, "BUY_VOL": float, "NEUTRAL": float}
-    iv_rank: float         # current IV rank (0-100) for context
+    iv_percentile: float   # current IV percentile (0-100) for context
     timestamp: str         # ISO 8601
 ```
 
 **How it affects structure selection**: See Section 4 decision matrix. In brief:
-- SELL_VOL → favor structures that collect premium (iron condors, credit spreads, short strangles)
-- BUY_VOL → favor structures that pay premium (long straddles, debit spreads, long strangles)
-- NEUTRAL → favor directional structures where theta is minimal relative to delta
+- SELL_VOL -> favor structures that collect premium (iron condors, credit spreads, short strangles)
+- BUY_VOL -> favor structures that pay premium (long straddles, debit spreads, long strangles)
+- NEUTRAL -> favor directional structures where theta is minimal relative to delta
 
 **Failure modes**:
-- **Kronos model load failure**: Model weights not downloaded or corrupted. **Mitigation**: Verify weights on startup; fall back to IV rank alone (heuristic: IV rank > 70 = SELL_VOL, < 30 = BUY_VOL, else NEUTRAL).
-- **Embedding quality insufficient**: Kronos hidden states may not encode vol-relevant information. **This is the central empirical risk**. Detectable in Phase 1 via linear probe AUC. If AUC < 0.55, the vol regime classifier adds no value and should be replaced with a simpler IV rank heuristic.
+- **Kronos model load failure**: Model weights not downloaded or corrupted. **Mitigation**: Verify weights on startup; fall back to IV percentile alone (heuristic: IV percentile > 70 = SELL_VOL, < 30 = BUY_VOL, else NEUTRAL).
+- **Embedding quality insufficient**: Kronos hidden states may not encode vol-relevant information. **This is the central empirical risk**. Detectable in Phase 1 via linear probe AUC. If AUC < 0.55, the vol regime classifier adds no value and should be replaced with a simpler IV percentile heuristic.
 - **Label noise**: The IV/RV relationship is noisy. SELL_VOL/BUY_VOL labels constructed from VIX may not correspond to single-name IV dynamics. **Mitigation**: Use ticker-specific IV when available (from options data); fall back to VIX only for index ETFs.
 - **CPU latency**: Kronos-mini forward pass on CPU is ~100-500ms per prediction [VALIDATE EMPIRICALLY]. This is acceptable for hourly/daily signals but would be a bottleneck for minute-level.
 
@@ -278,7 +281,7 @@ class VolRegimeSignal:
 
 ### Decision Matrix
 
-The decision matrix maps (ktrdr directional signal, Kronos vol regime, IV rank) to a specific options structure:
+The decision matrix maps (ktrdr directional signal, Kronos vol regime, IV percentile) to a specific options structure:
 
 ```
                           Kronos Vol Regime
@@ -389,6 +392,8 @@ Trades are only opened when signals meet minimum thresholds:
 
 If thresholds are not met, the system holds (no new position).
 
+These thresholds are empirical starting points derived from common options trading practice, not from optimization on ktrdr's signal distribution. During M3 (backtest), sweep the `min_ktrdr_confidence` gate across [0.40, 0.45, 0.50, 0.55] and report the effect on trade frequency and Sharpe. Use the backtest to select the threshold that maximizes Sharpe while keeping >= 50 trades over 2 years.
+
 ---
 
 ## 5. The Backtesting Strategy
@@ -412,6 +417,8 @@ If thresholds are not met, the system holds (no new position).
 
 3. **Classifier training**:
    - Train `nn.Linear(256, 3)` with cross-entropy loss on train set
+   - Class weights: `[1.0, 5.0, 8.0]` for [NEUTRAL, SELL_VOL, BUY_VOL] as a starting point (see Section 6 for expected class distribution). Tune based on actual observed label distribution.
+   - If NEUTRAL > 80% of labels, consider upsampling minority classes or using focal loss instead of weighted cross-entropy.
    - Early stopping on validation loss
    - No fine-tuning of Kronos weights
 
@@ -419,12 +426,12 @@ If thresholds are not met, the system holds (no new position).
 
    | Metric | Threshold for "Useful" | Why This Threshold |
    |--------|----------------------|-------------------|
-   | AUC (macro-averaged) | > 0.60 | Random classifier = 0.50; we need meaningful lift |
+   | AUC (per-class) | SELL_VOL AUC > 0.58 AND BUY_VOL AUC > 0.55 | Per-class AUC is more informative than macro-average when classes are heavily imbalanced; random = 0.50 |
    | Accuracy | > 0.45 | 3-class, so random = 0.33; but class imbalance matters more than accuracy |
    | Per-class precision | > 0.40 for SELL_VOL and BUY_VOL | We'd rather be right when we predict a regime than catch every regime |
    | Signal-following Sharpe | > 0.20 | Trade: sell straddle on SELL_VOL, buy straddle on BUY_VOL, flat on NEUTRAL |
 
-5. **Baseline comparison**: Compare Kronos classifier against a simple heuristic: IV rank > 70 = SELL_VOL, IV rank < 30 = BUY_VOL, else NEUTRAL. If Kronos doesn't beat this heuristic, the complexity isn't justified.
+5. **Baseline comparison**: Compare Kronos classifier against a simple heuristic: IV percentile > 70 = SELL_VOL, IV percentile < 30 = BUY_VOL, else NEUTRAL. If Kronos doesn't beat this heuristic, the complexity isn't justified.
 
 6. **[VALIDATE EMPIRICALLY]**: Does mean pooling of Kronos hidden states outperform last hidden state? Test both.
 
@@ -432,7 +439,9 @@ If thresholds are not met, the system holds (no new position).
 
 ### Phase 2: Synthetic Options Backtest
 
-**Objective**: Combine ktrdr directional signal + Kronos vol regime → select structure → compute P&L using synthetic options pricing → measure overall system Sharpe.
+**Objective**: Combine ktrdr directional signal + Kronos vol regime -> select structure -> compute P&L using synthetic options pricing -> measure overall system Sharpe.
+
+**Gate**: ktrdr model trained and validated for target symbol (see [PREREQUISITE] in Section 7).
 
 #### Options Data Availability
 
@@ -514,10 +523,10 @@ for each bar t in backtest_period:
     kronos_regime = kronos_classifier.predict(kronos_embedding_t)  # from pre-computed cache
     
     # 3. Get IV context
-    iv_rank_t = compute_iv_rank(vix_history, t)
+    iv_percentile_t = compute_iv_percentile(vix_history, t)
     
     # 4. Decision matrix → structure selection
-    structure = decision_matrix(ktrdr_signal, kronos_regime, iv_rank_t)
+    structure = decision_matrix(ktrdr_signal, kronos_regime, iv_percentile_t)
     
     # 5. If structure != NO_TRADE and confidence gates pass:
     #    a. Select strikes using B-S delta calculation
@@ -574,9 +583,9 @@ The options backtester is a **separate system** from ktrdr's existing `Backtesti
 **Required data range**: At least 3 years for meaningful options backtesting:
 - 1 year for Kronos classifier training
 - 2 years for out-of-sample options backtest
-- Additional data for IV rank computation (252-day lookback)
+- Additional data for IV percentile computation (252-day lookback)
 
-**[KARL INPUT NEEDED]**: Which symbols to start with? Recommendation: SPY (most liquid options, VIX is directly applicable) and one single-name stock from ktrdr's existing trained models.
+**[KARL INPUT NEEDED]**: Which symbols to start with? Recommendation: SPY (most liquid options, VIX is directly applicable) and one single-name stock from ktrdr's existing trained models. **Specific question**: Does a trained ktrdr model already exist for SPY? If not, training one is a prerequisite before M3 (see [PREREQUISITE] in Section 7).
 
 ### Historical Implied Volatility Data
 
@@ -590,16 +599,22 @@ The options backtester is a **separate system** from ktrdr's existing `Backtesti
 - CBOE LiveVol: Provides historical IV surface data
 - `[KARL INPUT NEEDED]`: Budget and priority for single-name IV data
 
-**IV rank computation**:
+**IV percentile computation**:
+
 ```python
-def iv_rank(iv_current: float, iv_history_252d: pd.Series) -> float:
-    """IV Rank = (current - 252d low) / (252d high - 252d low) * 100"""
-    iv_min = iv_history_252d.min()
-    iv_max = iv_history_252d.max()
-    if iv_max == iv_min:
-        return 50.0
-    return (iv_current - iv_min) / (iv_max - iv_min) * 100
+def compute_iv_percentile(iv_current: float, iv_history_252d: pd.Series) -> float:
+    """IV Percentile: fraction of days in the lookback window where IV was lower than today.
+    
+    This is NOT IV Rank (min-max normalization). IV Percentile is more robust to
+    outlier spikes — see Section 3 for the rationale.
+    
+    Returns 0-100. A value of 80 means current IV is higher than 80% of the
+    trailing 252 trading days.
+    """
+    return scipy.stats.percentileofscore(iv_history_252d, iv_current, kind='rank')
 ```
+
+**Note**: The same `compute_iv_percentile()` function is used in (a) label construction for the Kronos classifier, (b) signal aggregation for the decision matrix, (c) the `iv_percentile` field in `VolRegimeSignal`, and (d) the config schema thresholds (70/30). There is one metric and one function — no separate "IV Rank" concept in this system.
 
 ### Options Chain Data
 
@@ -626,22 +641,28 @@ def compute_realized_vol(prices: pd.Series, window: int = 20) -> pd.Series:
     log_returns = np.log(prices / prices.shift(1))
     return log_returns.rolling(window).std() * np.sqrt(252)
 
-def construct_vol_regime_labels(
+def build_vol_regime_labels(
     iv_series: pd.Series,        # daily IV (e.g., VIX/100)
     prices: pd.Series,           # daily close prices
     forward_window: int = 20,    # days to compute forward RV
-    iv_rank_high: float = 70,    # percentile for SELL_VOL
-    iv_rank_low: float = 30,     # percentile for BUY_VOL
+    iv_pctl_high: float = 70,    # percentile for SELL_VOL
+    iv_pctl_low: float = 30,     # percentile for BUY_VOL
     rv_discount: float = 0.85,   # RV < IV * discount = SELL_VOL
     rv_premium: float = 1.15,    # RV > IV * premium = BUY_VOL
 ) -> pd.Series:
-    """Returns labels: 0=NEUTRAL, 1=SELL_VOL, 2=BUY_VOL."""
-    iv_rank = compute_iv_rank_rolling(iv_series, 252)
+    """Returns labels: 0=NEUTRAL, 1=SELL_VOL, 2=BUY_VOL.
+    
+    [VALIDATE EMPIRICALLY]: Before training, print the label distribution.
+    If SELL_VOL or BUY_VOL < 5% of total labels, the AND thresholds may be 
+    too strict — loosen to iv_pctl_high=65 and/or rv_discount=0.90 to 
+    generate more training examples.
+    """
+    iv_percentile = compute_iv_percentile_rolling(iv_series, 252)
     rv_forward = compute_realized_vol(prices, forward_window).shift(-forward_window)
     
     labels = pd.Series(0, index=prices.index)  # default NEUTRAL
-    sell_vol_mask = (iv_rank > iv_rank_high) & (rv_forward < iv_series * rv_discount)
-    buy_vol_mask = (iv_rank < iv_rank_low) & (rv_forward > iv_series * rv_premium)
+    sell_vol_mask = (iv_percentile > iv_pctl_high) & (rv_forward < iv_series * rv_discount)
+    buy_vol_mask = (iv_percentile < iv_pctl_low) & (rv_forward > iv_series * rv_premium)
     labels[sell_vol_mask] = 1  # SELL_VOL
     labels[buy_vol_mask] = 2  # BUY_VOL
     
@@ -650,7 +671,9 @@ def construct_vol_regime_labels(
 
 **[ASSUMPTION]**: Using 20-day forward realized vol. This matches the ~30-day options DTE target. The exact forward window should be tested: 10, 15, 20, 30 days.
 
-**Label distribution estimate**: On typical equity indices (SPY), expect roughly 15-25% SELL_VOL, 10-20% BUY_VOL, 55-75% NEUTRAL. The class imbalance needs handling — focal loss or class-weighted cross-entropy.
+**Label distribution estimate**: Expect approximately **10-15% SELL_VOL, 5-10% BUY_VOL, 75-85% NEUTRAL** on typical equity indices (SPY). These estimates account for the joint probability of both AND conditions being satisfied simultaneously — elevated IV alone occurs ~25% of the time, but the additional requirement that realized vol actually comes in lower than IV reduces this to ~10-15%. BUY_VOL is even rarer because low-IV environments that are followed by vol expansion are uncommon (~5-10%). The exact distribution should be computed empirically during M1: run `build_vol_regime_labels()` on the training data and report the actual counts before training.
+
+**Class weights for training**: Use `[1.0, 5.0, 8.0]` for [NEUTRAL, SELL_VOL, BUY_VOL] as a starting point, then tune based on the actual observed label distribution. If NEUTRAL > 80% of labels, consider upsampling the minority classes or using focal loss instead of weighted cross-entropy.
 
 ### Risk-Free Rate
 
@@ -662,9 +685,14 @@ def construct_vol_regime_labels(
 
 ## 7. Integration Points with ktrdr
 
-### Lux → ktrdr REST API
+### Lux -> ktrdr REST API
 
 **Endpoint**: `POST /api/v1/models/predict`
+
+**[PREREQUISITE — VERIFY BEFORE M3]**: A trained ktrdr model for the target symbol (e.g., SPY) must exist at `models/{strategy_name}/{timeframe}_v{N}/` before the backtest can run. The model name referenced in this document (`trend_tb_lstm_signal_v1`) is an example from the ktrdr API documentation — it is NOT confirmed to be a trained, available model for SPY. If no model exists for SPY:
+- **Option A**: Use ktrdr's existing `BacktestingEngine` to train one (standard ktrdr training pipeline)
+- **Option B**: Use a different symbol where a trained model already exists (e.g., AAPL if a model is trained there)
+- **Do NOT proceed to M3 without confirming this.**
 
 **Request** (from `ktrdr/api/endpoints/models.py`, `PredictionRequest`):
 ```json
@@ -717,7 +745,7 @@ def construct_vol_regime_labels(
 
 **[ASSUMPTION]**: Using option 1 (persistent server). ktrdr's FastAPI server is lightweight — the main memory cost is the loaded neural network model(s), which are small (MLP: <1MB, LSTM/GRU: <10MB).
 
-### Options Backtester ↔ Existing BacktestingEngine
+### Options Backtester <-> Existing BacktestingEngine
 
 The options backtester is **separate** from the existing `BacktestingEngine`. The interaction is:
 
@@ -781,7 +809,7 @@ Opus 4.7 receives a structured JSON prompt with all relevant context:
         "probabilities": {"SELL_VOL": 0.68, "BUY_VOL": 0.12, "NEUTRAL": 0.20}
     },
     "vol_context": {
-        "iv_rank": 78.5,
+        "iv_percentile": 78.5,
         "current_iv": 0.22,
         "vix": 22.4,
         "rv_20d": 0.17
@@ -820,6 +848,8 @@ Opus 4.7 receives a structured JSON prompt with all relevant context:
 {
     "action": "OPEN",
     "structure": "bull_put_spread",
+    "source": "opus",
+    "matrix_agreed": true,
     "legs": [
         {"type": "SELL", "option_type": "PUT", "strike": 515, "expiry": "2026-05-16", "contracts": 2},
         {"type": "BUY", "option_type": "PUT", "strike": 510, "expiry": "2026-05-16", "contracts": 2}
@@ -833,11 +863,13 @@ Opus 4.7 receives a structured JSON prompt with all relevant context:
         "stop_loss_pct": 100,
         "time_exit_dte": 7
     },
-    "reasoning": "IV rank at 78.5 with BUY signal. Selling put spread collects elevated premium with directional support. Short 515 put at 0.22 delta gives room for pullback. Width of 5 limits max loss to $630 per spread. Two contracts = $1260 max risk within $2000 budget.",
+    "reasoning": "IV percentile at 78.5 with BUY signal. Selling put spread collects elevated premium with directional support. Short 515 put at 0.22 delta gives room for pullback. Width of 5 limits max loss to $630 per spread. Two contracts = $1260 max risk within $2000 budget.",
     "confidence": "HIGH",
     "warnings": []
 }
 ```
+
+The `source` field indicates whether this recommendation came from Opus 4.7 (`"opus"`) or the decision matrix fallback (`"matrix"`). The `matrix_agreed` field indicates whether Opus 4.7's recommendation matches what the decision matrix would have selected — see "Validation Gap" below.
 
 ### Is Opus 4.7 in the Backtest Hot Path?
 
@@ -851,11 +883,32 @@ Opus 4.7 is used only in **live/paper trading**, where:
 
 **[ASSUMPTION]**: Opus 4.7 is called via the Anthropic API using Lux's existing API key. No separate authentication needed.
 
+### Validation Gap: Backtest vs Live System
+
+The synthetic backtest (Phase 2) validates the **decision matrix only**. The live system adds Opus 4.7, which can **override** the decision matrix. These are different systems, and a Sharpe > 0.50 in synthetic backtest says nothing about what happens when Opus 4.7 makes different choices.
+
+**What "Opus override" means**: Opus 4.7 changes the selected structure (e.g., bull put spread -> iron condor), changes strikes or expiry beyond what the matrix specified, declines to trade when the matrix would trade, or recommends a trade when the matrix would not. Any of these count as a divergence from the matrix path.
+
+**Live tracking protocol** to close the validation gap:
+
+1. **Tag every trade by source**: Every `TradeRecommendation` records `source: "opus" | "matrix"` and `matrix_agreed: bool`. When Opus 4.7 is called and its output matches the matrix suggestion (same structure, similar strikes), `source` is `"opus"` but `matrix_agreed` is `true`. When Opus diverges, `matrix_agreed` is `false`.
+
+2. **Track performance separately**: The `calibration` table tracks P&L, win rate, and per-trade Sharpe contribution separately by source:
+   - `matrix_agreed == true`: trades where Opus followed the matrix
+   - `matrix_agreed == false`: trades where Opus overrode the matrix
+   - This separation reveals whether Opus overrides add or destroy value
+
+3. **Evaluate after sufficient data**: After 30+ live/paper trades with at least 10 Opus-override trades:
+   - Compare P&L, Sharpe, and win rate between override and non-override trades
+   - If Opus diverges from the matrix on >30% of trades AND Opus-override trades underperform matrix-agreed trades by >15% on P&L, disable Opus reasoning and fall back to matrix-only mode
+
+4. **The paper trading phase (M5) is where the live system is actually validated**, not the synthetic backtest. The synthetic backtest validates the decision matrix as a strategy; paper trading validates the full system including Opus 4.7's judgment, real bid/ask spreads, execution quality, and end-to-end reliability.
+
 ### Failure Modes
 
 | Failure | Impact | Mitigation |
 |---------|--------|------------|
-| Opus 4.7 API unavailable (outage, rate limit) | Cannot get reasoning for new trades | Fall back to decision matrix output directly; no Opus override. Log the fallback. |
+| Opus 4.7 API unavailable (outage, rate limit) | Cannot get reasoning for new trades | Fall back to decision matrix output directly; record `source: "matrix"`. Log the fallback. |
 | Opus 4.7 returns malformed JSON | Cannot parse trade recommendation | Validate response schema. If invalid after 2 retries, use decision matrix fallback. |
 | Opus 4.7 takes > 60 seconds | Blocks the analysis cycle | Set 60-second timeout. Use decision matrix fallback on timeout. |
 | Opus 4.7 recommends structure outside scope | Could introduce unwanted risk | Validate `structure` field against allowed list. Reject and retry with explicit constraint. |
@@ -869,7 +922,7 @@ Opus 4.7 is used only in **live/paper trading**, where:
 
 ### [KARL INPUT NEEDED]
 
-1. **Which symbols to start with?** Recommendation: SPY first (most liquid options, VIX directly applicable). Which single-name stock second?
+1. **Which symbols to start with?** Recommendation: SPY first (most liquid options, VIX directly applicable). Which single-name stock second? **Critical**: Does a trained ktrdr model already exist for SPY? If not, training one is a prerequisite before M3.
 
 2. **Budget for historical options data?** $0 (VIX + Black-Scholes reconstruction), ~$200 (OptionsDX for 2-3 symbols), or $1000+ (CBOE DataShop)?
 
@@ -885,7 +938,7 @@ Opus 4.7 is used only in **live/paper trading**, where:
 
 ### [VALIDATE EMPIRICALLY]
 
-1. **Kronos embedding quality for vol classification**: Does AUC > 0.60? This is the central empirical question. If it fails, fall back to IV rank heuristic.
+1. **Kronos embedding quality for vol classification**: Does AUC > 0.60? This is the central empirical question. If it fails, fall back to IV percentile heuristic.
 
 2. **Kronos-mini vs Kronos-small**: Which embedding dimension (256 vs 512) produces better vol regime classification? Start with mini for speed.
 
@@ -895,13 +948,17 @@ Opus 4.7 is used only in **live/paper trading**, where:
 
 5. **Optimal DTE for each structure**: The design specifies 14-45 days depending on structure. Backtest should test 14, 21, 30, 45 DTE for each structure type.
 
-6. **Label construction thresholds**: The 70/30 IV rank percentiles and 0.85/1.15 RV/IV multipliers are starting points. Sensitivity analysis needed.
+6. **Label construction thresholds**: The 70/30 IV percentile thresholds and 0.85/1.15 RV/IV multipliers are starting points. Sensitivity analysis needed.
 
 7. **Exit timing**: Take profit at 50% of max profit, or 40%, or 60%? Stop loss at max loss, or earlier at 75%? Backtest should sweep these parameters.
 
 8. **Kronos CPU inference latency**: Expected ~100-500ms on CPU for Kronos-mini. Verify on Karl's Docker stack.
 
-9. **Signal combination method**: The decision matrix is rule-based. An alternative is to train a small model that takes (ktrdr probabilities, Kronos regime probabilities, IV rank) as input and outputs structure probabilities. Start with rules, test learned combination if rules work.
+9. **Signal combination method**: The decision matrix is rule-based. An alternative is to train a small model that takes (ktrdr probabilities, Kronos regime probabilities, IV percentile) as input and outputs structure probabilities. Start with rules, test learned combination if rules work.
+
+10. **Label distribution on actual training data**: Run `build_vol_regime_labels()` on the training data before training the classifier. If SELL_VOL < 5% or BUY_VOL < 5%, loosen thresholds (e.g., `iv_pctl_high=65`, `rv_discount=0.90`).
+
+11. **Confidence gate sweep**: During M3, sweep `min_ktrdr_confidence` across [0.40, 0.45, 0.50, 0.55]. Select the threshold that maximizes Sharpe while keeping >= 50 trades over 2 years.
 
 ### [ASSUMPTION]
 
@@ -909,7 +966,7 @@ Opus 4.7 is used only in **live/paper trading**, where:
 
 2. **2% max risk per trade**: Conservative baseline. Adjustable.
 
-3. **Opus 4.7 not in backtest hot path**: Decision matrix is applied deterministically in backtests. Opus is only used for live/paper to provide nuanced reasoning.
+3. **Opus 4.7 not in backtest hot path**: Decision matrix is applied deterministically in backtests. Opus is only used for live/paper to provide nuanced reasoning. The backtest validates the matrix; paper trading validates the full system including Opus (see Section 8, "Validation Gap").
 
 4. **No position correlation**: Each trade is sized independently. No portfolio-level Greek management in Phase 1.
 
@@ -917,7 +974,7 @@ Opus 4.7 is used only in **live/paper trading**, where:
 
 6. **Kronos frozen embeddings contain vol information**: This is the central hypothesis. If false, the vol regime classifier should be replaced with a simpler approach (e.g., train a small LSTM directly on OHLCV + VIX for vol regime classification, without Kronos).
 
-7. **ktrdr trained models exist for target symbols**: Karl has already trained ktrdr models that produce directional signals for the target symbols. If not, training must happen first.
+7. **ktrdr trained models exist for target symbols**: Karl has already trained ktrdr models that produce directional signals for the target symbols. If not, training must happen first (see [PREREQUISITE] in Section 7).
 
 8. **Lux can call Python functions directly**: Lux can import and run `KronosFeatureProvider` as a Python module, not just via REST API. This avoids needing a separate Kronos microservice.
 
@@ -927,7 +984,8 @@ Opus 4.7 is used only in **live/paper trading**, where:
 
 | Term | Definition |
 |------|-----------|
-| **IV Rank** | Current IV's percentile position relative to its 252-day range (0-100) |
+| **IV Percentile** | The fraction of days in the trailing 252-day window where IV was lower than today's IV (0-100). A value of 80 means today's IV is higher than 80% of recent days. This is the sole IV-relative metric used in this system — see Section 3 for rationale. |
+| **IV Rank** | An alternative metric (NOT used in this system): `(current - 252d_low) / (252d_high - 252d_low) * 100`. Sensitive to outlier spikes; see Section 3 for why IV Percentile was chosen instead. |
 | **DTE** | Days to expiry for an options contract |
 | **ATM** | At-the-money: strike price equal to current underlying price |
 | **OTM** | Out-of-the-money: strike price above (calls) or below (puts) current price |

--- a/docs/designs/autonomous-options-trading/DESIGN.md
+++ b/docs/designs/autonomous-options-trading/DESIGN.md
@@ -1,0 +1,961 @@
+# ktrdr Autonomous Options Trading System — Design Document
+
+> **Author**: Claude (Opus 4.6), commissioned by Karl Piteira
+> **Date**: 2026-04-18
+> **Status**: Draft — awaiting Karl's review before architecture phase
+> **Grounded in**: ktrdr codebase analysis (`KTRDR_REALITY_MAP.md`), Kronos integration spec (`spec.md`)
+
+---
+
+## 1. Problem Statement
+
+### What Problem Does This Solve?
+
+Karl has a working directional trading system (ktrdr) with a Sharpe ratio ceiling of 0.181. The system uses hand-crafted technical indicators passed through fuzzy membership functions into a neural network to produce BUY/SELL/HOLD signals. This signal is accurate enough to be profitable on stocks but not enough to justify the capital commitment at meaningful scale.
+
+**The core insight**: A directional signal with 55-65% accuracy produces mediocre returns on linear stock trades, but the same signal routed through options structures generates asymmetric payoffs. A correct BUY signal that triggers buying a call spread pays 2-5x the risk, while an incorrect signal loses only the premium. Combined with a vol regime signal (from Kronos) that informs *which* options structure to use, the system can match structure to market conditions rather than applying one-size-fits-all directional bets.
+
+### What Does Success Look Like?
+
+| Milestone | Metric | Timeline |
+|-----------|--------|----------|
+| Vol regime signal validates | Kronos classifier AUC > 0.60 on held-out IV data | Phase 1 (weeks 1-2) |
+| Synthetic backtest shows edge | Combined system Sharpe > 0.50 on 2-year synthetic options backtest | Phase 2 (weeks 3-5) |
+| Paper trading confirms | Paper Sharpe > 0.40 over 60+ trading days with > 30 trades | Phase 3 (months 2-4) |
+| Live deployment | Sharpe > 0.35 on real capital, max drawdown < 15% | Phase 4 (month 5+) |
+
+**The Sharpe targets are deliberately conservative**. A Sharpe of 0.50 on synthetic backtest with Black-Scholes reconstruction has known approximation errors (see Section 5); paper trading at 0.40 accounts for real-world slippage. If these targets are met, the system has genuine edge.
+
+### Non-Goals
+
+- **High-frequency options trading**: ktrdr operates at bar-level granularity (1h-1d). This system targets swing options (5-45 DTE), not intraday scalping.
+- **Exotic options**: No barriers, digitals, or path-dependent exotics. Vanilla calls, puts, and standard multi-leg structures only.
+- **Market making / delta-neutral strategies**: This system is directional-first. Vol regime informs structure selection, not standalone vol trading.
+- **Fully automated execution without human oversight**: Lux recommends trades and can paper-trade autonomously, but live execution requires Karl's approval until paper trading validates the system.
+- **Multi-asset portfolio optimization**: Single-name options on one ticker at a time. Portfolio-level correlation management is out of scope.
+- **Replacing ktrdr's core ML pipeline**: The options layer sits *on top of* ktrdr's existing signal. Phase 1 of Kronos integration (replacing fuzzy features) is specced separately.
+
+---
+
+## 2. System Overview
+
+### High-Level Architecture
+
+```
+                    +-----------------+
+                    |   Lux (24/7)    |
+                    |  Orchestrator   |
+                    +--------+--------+
+                             |
+              +--------------+--------------+
+              |              |              |
+              v              v              v
+    +------------------+  +--------+  +------------------+
+    | ktrdr REST API   |  | Kronos |  | Options Data     |
+    | POST /api/v1/    |  | Vol    |  | (yfinance/CBOE/  |
+    | models/predict   |  | Regime |  |  IBKR chain)     |
+    +--------+---------+  +---+----+  +--------+---------+
+             |                |                |
+             v                v                v
+    +--------------------------------------------------+
+    |           Signal Aggregation Layer                |
+    |  ktrdr signal + Kronos regime + IV rank/data     |
+    +------------------------+-------------------------+
+                             |
+                             v
+    +--------------------------------------------------+
+    |              Opus 4.7 Reasoning                  |
+    |  Input: structured JSON (signals + chain data)   |
+    |  Output: structure + strikes + expiry + size     |
+    +------------------------+-------------------------+
+                             |
+                             v
+    +--------------------------------------------------+
+    |            Position Management                    |
+    |  Track open positions, Greeks, P&L               |
+    |  Managed by Lux in local state                   |
+    +------------------------+-------------------------+
+                             |
+                             v
+    +--------------------------------------------------+
+    |              Execution Target                     |
+    |  Backtest (synthetic) -> Paper (IBKR) -> Live    |
+    +--------------------------------------------------+
+```
+
+### Component List
+
+| Component | Responsibility |
+|-----------|---------------|
+| **Lux** | Orchestrates the entire flow: polls ktrdr, runs Kronos, calls Opus 4.7, manages positions, reports via Telegram |
+| **ktrdr REST API** | Produces directional signal (BUY/SELL/HOLD + probability distribution) from existing trained models |
+| **Kronos Vol Regime Classifier** | Classifies current market as SELL_VOL / BUY_VOL / NEUTRAL based on frozen Kronos embeddings + trained linear head |
+| **Options Data Provider** | Supplies IV rank, options chain data, and historical IV for backtesting |
+| **Signal Aggregation** | Combines ktrdr directional signal, Kronos vol regime, and IV context into a structured decision input |
+| **Opus 4.7 Reasoning** | Selects optimal options structure, strikes, expiry, and position size given the aggregated signal |
+| **Position Manager** | Tracks open options positions, monitors Greeks, triggers exit conditions |
+| **Backtest Engine (Options)** | Reconstructs historical options P&L via Black-Scholes for strategy validation |
+
+### Data Flow: "Lux Triggers Analysis" to "Recommendation Produced"
+
+1. **Trigger**: Lux runs on a schedule (e.g., every hour for 1h bars, every day for 1d bars) or on demand via Telegram command.
+
+2. **Fetch ktrdr signal**: Lux sends `POST /api/v1/models/predict` to ktrdr server with `{model_name, symbol, timeframe}`. Receives `{signal, confidence, signal_strength}` plus `input_features`.
+
+3. **Fetch Kronos vol regime**: Lux calls the Kronos classifier (Python function, not REST — runs in Lux's process or via subprocess). Inputs recent OHLCV bars. Receives `{regime: SELL_VOL|BUY_VOL|NEUTRAL, confidence: float}`.
+
+4. **Fetch options context**: Lux retrieves current IV rank (from VIX for indices, or from options chain data for single names) and the relevant options chain (strikes, expiries, bid/ask).
+
+5. **Aggregate and call Opus 4.7**: Lux constructs a structured JSON prompt containing the ktrdr signal, Kronos regime, IV data, and options chain. Sends to Opus 4.7 via Anthropic API with extended thinking enabled.
+
+6. **Opus 4.7 responds**: Returns a structured JSON with selected structure, specific strikes, expiry, position size, and reasoning.
+
+7. **Lux acts**: In backtest mode, logs the synthetic trade. In paper mode, submits order to IBKR paper. In live mode, submits real order (with Karl's approval gate).
+
+---
+
+## 3. The Two ML Signals
+
+### Signal 1: ktrdr Directional Signal
+
+**What it encodes**: The probability that the underlying asset will move up (BUY), down (SELL), or stay flat (HOLD) over the model's prediction horizon. This is a supervised classification output trained on historical price movements using triple barrier, zigzag, or forward return labels.
+
+**How it's produced**: 
+
+The signal originates from ktrdr's neural network (`ktrdr/neural/models/base_model.py`, `predict()` method, lines 57-250). The production path for live/external consumption:
+
+1. Raw OHLCV data is loaded from ktrdr's data layer (`ktrdr/data/local_data_loader.py`)
+2. `IndicatorEngine` (`ktrdr/indicators/indicator_engine.py`) computes ~28 technical indicators
+3. `FuzzyEngine` (`ktrdr/fuzzy/engine.py`) converts indicator values to fuzzy membership degrees (0-1)
+4. `FuzzyNeuralProcessor` (`ktrdr/training/fuzzy_neural_processor.py`) assembles features into `torch.FloatTensor`
+5. Neural network (MLP/LSTM/GRU) produces softmax probabilities over {BUY, HOLD, SELL}
+6. `DecisionOrchestrator` (`ktrdr/decision/orchestrator.py`, lines 216-243) applies position-aware filters
+
+**How Lux calls it**:
+
+```
+POST /api/v1/models/predict
+Content-Type: application/json
+
+{
+    "model_name": "trend_tb_lstm_signal_v1",
+    "symbol": "AAPL",
+    "timeframe": "1h",
+    "test_date": "2026-04-18T14:30:00"   // optional; defaults to latest bar
+}
+```
+
+Response (from `ktrdr/api/endpoints/models.py`, `PredictionResponse`, lines 194-229):
+
+```json
+{
+    "success": true,
+    "model_name": "trend_tb_lstm_signal_v1",
+    "symbol": "AAPL",
+    "test_date": "2026-04-18T14:30:00",
+    "prediction": {
+        "signal": "BUY",
+        "confidence": 0.756,
+        "signal_strength": 0.694
+    },
+    "input_features": {
+        "1h_rsi_momentum_oversold": 0.02,
+        "1h_rsi_momentum_overbought": 0.83,
+        ...
+    }
+}
+```
+
+**Which output fields matter for options decisions**:
+
+The top-level `signal` and `confidence` are insufficient. The options layer needs the **full probability distribution** — `{"BUY": 0.756, "HOLD": 0.182, "SELL": 0.062}` — because:
+- A signal with P(BUY)=0.55, P(HOLD)=0.40, P(SELL)=0.05 suggests a different structure than P(BUY)=0.55, P(HOLD)=0.05, P(SELL)=0.40
+- The former is weakly directional; the latter is high-conviction directional with tail risk
+
+**[KARL INPUT NEEDED]**: The current `PredictionResponse` schema returns `signal_strength` but not the full `nn_probabilities` dict. The `reasoning` dict in `TradingDecision` contains `nn_probabilities`, but it's not exposed through the REST API. **Decision needed**: Either (a) extend the `/predict` endpoint to include probabilities, or (b) have Lux call ktrdr as a Python library directly (bypassing REST). Option (a) is cleaner — it's a ~10-line change to the API endpoint.
+
+**Confidence thresholding**:
+
+| Max Probability | Interpretation | Action |
+|-----------------|---------------|--------|
+| < 0.45 | Model uncertain, probabilities near uniform | HOLD — do not open new positions |
+| 0.45 - 0.60 | Weak directional signal | Small position, prefer defined-risk structures |
+| 0.60 - 0.75 | Moderate directional signal | Standard position size |
+| > 0.75 | Strong directional signal | Allow larger position, consider directional structures |
+
+These thresholds interact with Kronos regime — see Section 4 decision matrix.
+
+**Failure modes**:
+- **Model degradation**: ktrdr signal accuracy decays as market regime shifts away from training data. Detectable via running accuracy on recent signals. **Mitigation**: Retrain periodically; Lux monitors win rate.
+- **API unavailability**: ktrdr server is down or unreachable. **Mitigation**: Lux retries 3x with exponential backoff; if still down, hold all positions (no new trades).
+- **Stale data**: ktrdr's local OHLCV cache hasn't been updated. The prediction uses old bars. **Mitigation**: Check `test_date` in response against current time; alert if > 2 bars stale.
+- **All-HOLD degeneration**: Model learns to predict HOLD for everything (high accuracy on imbalanced data). **Detectable**: Track signal distribution over rolling 30-day window.
+
+### Signal 2: Kronos Vol Regime Classifier
+
+**What it encodes**: Whether the current market environment favors being long volatility (BUY_VOL — IV is likely to rise, realized vol will increase), short volatility (SELL_VOL — IV is elevated relative to likely realized vol, premium is rich), or neither (NEUTRAL — no clear vol edge).
+
+**How it's produced**:
+
+This is a **separate trained classifier** on top of **frozen** Kronos embeddings. It is NOT Kronos itself making vol predictions — Kronos is a generative model for K-lines. We use its hidden states as learned representations of market microstructure.
+
+**Architecture**:
+
+```
+Recent OHLCV bars (last N bars, N up to 512)
+    |
+    v
+Kronos-mini (frozen, 4.1M params)
+    |
+    v
+Transformer hidden states: (batch, seq_len, 256)
+    |
+    v
+Last hidden state: (batch, 256)     // or mean pool — [VALIDATE EMPIRICALLY]
+    |
+    v
+Linear classifier head (256 -> 3)   // trained on vol regime labels
+    |
+    v
+Softmax -> {SELL_VOL: float, BUY_VOL: float, NEUTRAL: float}
+```
+
+**Training the classifier head**:
+
+The classifier is trained on historical data where the label is derived from the relationship between implied volatility (IV) and subsequent realized volatility (RV):
+
+```
+Label construction:
+  1. For each bar t, compute:
+     - IV_rank_t = percentile rank of current IV over trailing 252 trading days
+     - RV_forward = realized volatility over the next N trading days (N = target holding period, e.g., 20 days)
+     - IV_t = current implied volatility (from VIX for indices, or from ATM option IV for single names)
+  
+  2. Assign label:
+     - SELL_VOL:  IV_rank_t > 70th percentile AND RV_forward < IV_t * 0.85
+                  (IV is high AND realized vol came in lower — selling premium was correct)
+     - BUY_VOL:   IV_rank_t < 30th percentile AND RV_forward > IV_t * 1.15
+                  (IV is low AND realized vol expanded — buying options was correct)
+     - NEUTRAL:   everything else
+```
+
+**[ASSUMPTION]**: The 70th/30th percentile thresholds and the 0.85/1.15 multipliers are starting points. These should be tuned during Phase 1 validation. The label construction must avoid look-ahead bias — labels are based on *future* realized vol but the *features* (Kronos embeddings) use only past bars.
+
+**Training procedure**:
+
+1. Pre-compute Kronos embeddings for the entire training period (cache to disk as `.pt` files)
+2. Construct IV/RV labels for each bar (requires historical IV data — see Section 6)
+3. Train a linear layer (256 -> 3) with cross-entropy loss, using standard train/val/test split
+4. Freeze the linear head after training
+5. **No fine-tuning of Kronos itself** in Phase 1 — the hypothesis is that frozen embeddings already encode vol-relevant information
+
+**Output format**:
+
+```python
+@dataclass
+class VolRegimeSignal:
+    regime: str            # "SELL_VOL" | "BUY_VOL" | "NEUTRAL"
+    confidence: float      # max probability (0.0-1.0)
+    probabilities: dict    # {"SELL_VOL": float, "BUY_VOL": float, "NEUTRAL": float}
+    iv_rank: float         # current IV rank (0-100) for context
+    timestamp: str         # ISO 8601
+```
+
+**How it affects structure selection**: See Section 4 decision matrix. In brief:
+- SELL_VOL → favor structures that collect premium (iron condors, credit spreads, short strangles)
+- BUY_VOL → favor structures that pay premium (long straddles, debit spreads, long strangles)
+- NEUTRAL → favor directional structures where theta is minimal relative to delta
+
+**Failure modes**:
+- **Kronos model load failure**: Model weights not downloaded or corrupted. **Mitigation**: Verify weights on startup; fall back to IV rank alone (heuristic: IV rank > 70 = SELL_VOL, < 30 = BUY_VOL, else NEUTRAL).
+- **Embedding quality insufficient**: Kronos hidden states may not encode vol-relevant information. **This is the central empirical risk**. Detectable in Phase 1 via linear probe AUC. If AUC < 0.55, the vol regime classifier adds no value and should be replaced with a simpler IV rank heuristic.
+- **Label noise**: The IV/RV relationship is noisy. SELL_VOL/BUY_VOL labels constructed from VIX may not correspond to single-name IV dynamics. **Mitigation**: Use ticker-specific IV when available (from options data); fall back to VIX only for index ETFs.
+- **CPU latency**: Kronos-mini forward pass on CPU is ~100-500ms per prediction [VALIDATE EMPIRICALLY]. This is acceptable for hourly/daily signals but would be a bottleneck for minute-level.
+
+---
+
+## 4. Options Structure Selection Logic
+
+### Decision Matrix
+
+The decision matrix maps (ktrdr directional signal, Kronos vol regime, IV rank) to a specific options structure:
+
+```
+                          Kronos Vol Regime
+                    SELL_VOL        NEUTRAL         BUY_VOL
+                 +---------------+---------------+---------------+
+   ktrdr    BUY  | Bull Put      | Bull Call      | Long Call     |
+   Signal        | Spread (1)    | Spread (3)     | (5)           |
+                 +---------------+---------------+---------------+
+            HOLD | Iron           | No Trade       | Long          |
+                 | Condor (2)    | (skip)         | Straddle (6)  |
+                 +---------------+---------------+---------------+
+            SELL | Bear Call      | Bear Put       | Long Put      |
+                 | Spread (4)    | Spread (7)     | (8)           |
+                 +---------------+---------------+---------------+
+```
+
+### Structure Details
+
+**(1) Bull Put Spread** (BUY + SELL_VOL): Directionally bullish, premium is rich.
+- Sell OTM put, buy further OTM put (same expiry)
+- Collects net credit; profits if underlying stays above short strike
+- Max profit: net credit. Max loss: width - credit.
+- DTE: 30-45 days. Short strike: ~0.30 delta. Width: 1-2 strikes.
+
+**(2) Iron Condor** (HOLD + SELL_VOL): No directional view, but IV is elevated — sell premium on both sides.
+- Sell OTM put + sell OTM call, buy further OTM put + buy further OTM call
+- Max profit: net credit. Max loss: width - credit.
+- DTE: 30-45 days. Short strikes: ~0.16 delta on each side. Wing width: 1-2 strikes.
+
+**(3) Bull Call Spread** (BUY + NEUTRAL): Directionally bullish, no vol edge — keep it simple.
+- Buy ATM/slightly OTM call, sell further OTM call
+- Max profit: width - debit. Max loss: debit paid.
+- DTE: 21-35 days. Long strike: ~0.45 delta. Width: 2-3 strikes.
+
+**(4) Bear Call Spread** (SELL + SELL_VOL): Directionally bearish, premium is rich.
+- Sell OTM call, buy further OTM call
+- Mirror of (1) on the put side.
+
+**(5) Long Call** (BUY + BUY_VOL): Directionally bullish AND vol is expected to expand — maximum convexity.
+- Buy OTM call
+- Unlimited upside, loss limited to premium.
+- DTE: 14-30 days. Strike: ~0.35-0.40 delta.
+- **Only used when ktrdr confidence > 0.65** — naked long options decay fast.
+
+**(6) Long Straddle** (HOLD + BUY_VOL): No directional view but expecting vol expansion.
+- Buy ATM call + ATM put
+- Profits from large move in either direction.
+- DTE: 14-30 days. Strike: ATM.
+- **Only used when Kronos BUY_VOL confidence > 0.70** — straddles are expensive.
+
+**(7) Bear Put Spread** (SELL + NEUTRAL): Directionally bearish, no vol edge.
+- Buy ATM/slightly OTM put, sell further OTM put.
+- Mirror of (3).
+
+**(8) Long Put** (SELL + BUY_VOL): Directionally bearish AND vol expanding.
+- Buy OTM put. Mirror of (5).
+
+### Structures In Scope
+
+- Vertical spreads (bull/bear, call/put)
+- Iron condors
+- Long calls and puts (single-leg)
+- Long straddles
+
+### Structures Explicitly Out of Scope
+
+- **Calendar/diagonal spreads**: Require modeling term structure; too complex for Phase 1.
+- **Butterflies**: Narrow max-profit zone; poor risk/reward for a noisy directional signal.
+- **Ratio spreads**: Undefined risk on one side; requires precise vol modeling.
+- **Naked short options**: Unlimited risk; not appropriate for an automated system.
+- **Strangles (short)**: Unlimited risk on both sides. Iron condors are the defined-risk equivalent.
+- **Covered calls/puts**: Requires holding underlying; out of scope for pure options system.
+
+### How ktrdr Probabilities Affect Sizing
+
+The probability distribution from ktrdr informs not just direction but position size:
+
+```
+position_size_multiplier = f(max_probability, probability_spread)
+
+where:
+  max_probability = max(P_BUY, P_HOLD, P_SELL)
+  probability_spread = max_probability - second_highest_probability
+  
+  if probability_spread < 0.10:
+      # Model is uncertain between two outcomes
+      position_size_multiplier = 0.5
+  elif probability_spread < 0.25:
+      position_size_multiplier = 0.75
+  else:
+      position_size_multiplier = 1.0
+
+max_risk_per_trade = account_value * 0.02 * position_size_multiplier
+```
+
+**[ASSUMPTION]**: 2% max risk per trade is the base allocation. This is conservative for options (where defined-risk structures have known max loss) but appropriate for an early-stage system. Karl may want to adjust this.
+
+### Confidence Gates
+
+Trades are only opened when signals meet minimum thresholds:
+
+| Condition | Minimum Threshold |
+|-----------|------------------|
+| ktrdr max probability | 0.45 (for any directional trade) |
+| ktrdr max probability (for naked long options: 5, 8) | 0.65 |
+| Kronos regime confidence (for vol-specific structures: 2, 6) | 0.70 |
+| Kronos regime confidence (for all other structures) | 0.50 |
+
+If thresholds are not met, the system holds (no new position).
+
+---
+
+## 5. The Backtesting Strategy
+
+### Phase 1: Kronos Vol Regime Signal Quality Validation
+
+**Objective**: Determine whether Kronos embeddings contain information about future volatility regimes that a simple classifier can extract.
+
+**Method**:
+
+1. **Data preparation**:
+   - Load historical OHLCV for target symbols from ktrdr's data layer (`data/{timeframe}/{Symbol}_{Timeframe}.csv`)
+   - Load historical IV data (source: VIX daily from yfinance for SPY/SPX; CBOE DataShop for single names if budget permits — see Section 6)
+   - Compute labels for each bar: SELL_VOL / BUY_VOL / NEUTRAL (per Section 3 label construction)
+   - Split: 70% train, 15% validation, 15% test, chronological split (no shuffling — this is time series)
+
+2. **Embedding extraction**:
+   - Run Kronos-mini on sliding windows of OHLCV data
+   - Extract last hidden state: shape `(num_bars, 256)`
+   - Cache embeddings to disk as `.pt` files (one per symbol/timeframe)
+
+3. **Classifier training**:
+   - Train `nn.Linear(256, 3)` with cross-entropy loss on train set
+   - Early stopping on validation loss
+   - No fine-tuning of Kronos weights
+
+4. **Evaluation metrics**:
+
+   | Metric | Threshold for "Useful" | Why This Threshold |
+   |--------|----------------------|-------------------|
+   | AUC (macro-averaged) | > 0.60 | Random classifier = 0.50; we need meaningful lift |
+   | Accuracy | > 0.45 | 3-class, so random = 0.33; but class imbalance matters more than accuracy |
+   | Per-class precision | > 0.40 for SELL_VOL and BUY_VOL | We'd rather be right when we predict a regime than catch every regime |
+   | Signal-following Sharpe | > 0.20 | Trade: sell straddle on SELL_VOL, buy straddle on BUY_VOL, flat on NEUTRAL |
+
+5. **Baseline comparison**: Compare Kronos classifier against a simple heuristic: IV rank > 70 = SELL_VOL, IV rank < 30 = BUY_VOL, else NEUTRAL. If Kronos doesn't beat this heuristic, the complexity isn't justified.
+
+6. **[VALIDATE EMPIRICALLY]**: Does mean pooling of Kronos hidden states outperform last hidden state? Test both.
+
+**Timeline**: ~2 weeks. Most time is in data preparation and embedding extraction.
+
+### Phase 2: Synthetic Options Backtest
+
+**Objective**: Combine ktrdr directional signal + Kronos vol regime → select structure → compute P&L using synthetic options pricing → measure overall system Sharpe.
+
+#### Options Data Availability
+
+| Source | Data | Cost | Quality |
+|--------|------|------|---------|
+| **yfinance** | Current options chains, VIX history, underlying OHLCV | Free | No historical chains — current snapshot only |
+| **CBOE DataShop** | Historical end-of-day options data | ~$200-2000/dataset | Gold standard for US equities |
+| **OptionsDX** | Historical EOD options (CSV format) | ~$50-200/symbol/year | Good quality, affordable |
+| **VIX (via yfinance)** | Daily VIX close | Free | Available back to 1990 |
+| **Treasury rates (FRED)** | Risk-free rate for B-S | Free | Daily, reliable |
+
+**[KARL INPUT NEEDED]**: Budget for historical options data. Options:
+- **$0 path**: Use VIX + Black-Scholes reconstruction (lower fidelity, but free). Suitable for Phase 2 proof-of-concept.
+- **~$200 path**: OptionsDX data for 2-3 key symbols. Real bid/ask spreads, real IV surface.
+- **~$1000+ path**: CBOE DataShop for comprehensive coverage.
+
+Recommendation: Start with $0 path (Black-Scholes reconstruction) for Phase 2. If results are promising, validate with OptionsDX data before paper trading.
+
+#### Black-Scholes Reconstruction Method
+
+For each bar at time $t$ where the system would trade:
+
+```
+Given:
+  S_t     = underlying price (from ktrdr OHLCV data)
+  K       = strike price (selected by the decision matrix based on delta target)
+  T       = time to expiry in years (DTE / 365)
+  r       = risk-free rate (from FRED Treasury data, daily)
+  sigma_t = implied volatility estimate
+
+Option price:
+  C(S, K, T, r, sigma) = S * N(d1) - K * e^(-rT) * N(d2)
+  P(S, K, T, r, sigma) = K * e^(-rT) * N(-d2) - S * N(-d1)
+
+  where:
+    d1 = (ln(S/K) + (r + sigma^2/2) * T) / (sigma * sqrt(T))
+    d2 = d1 - sigma * sqrt(T)
+    N(x) = standard normal CDF
+
+Delta (for strike selection):
+  delta_call = N(d1)
+  delta_put  = N(d1) - 1
+```
+
+**IV estimation for historical reconstruction** (the $0 path):
+
+```
+sigma_t = VIX_t / 100 * IV_scalar
+
+where:
+  VIX_t = VIX close on day t
+  IV_scalar = adjustment factor for single-name vs index vol
+              (for SPY: IV_scalar = 1.0; for single names: estimate from beta)
+              IV_scalar_approx = max(0.8, min(2.0, beta_stock * 0.9 + 0.3))
+```
+
+**[ASSUMPTION]**: Using VIX as IV proxy for all underlyings is a significant approximation. Single-name IV can deviate substantially from VIX. This is acceptable for proof-of-concept but NOT for production decisions. Paper trading with real IBKR chain data is the true validation.
+
+**Known approximation errors in Black-Scholes reconstruction**:
+
+1. **Volatility smile/skew ignored**: B-S assumes flat vol across strikes. Real options have higher IV for OTM puts (skew). Impact: underestimates put prices, overestimates bull put spread credit. Magnitude: 5-20% pricing error for OTM options.
+
+2. **Bid/ask spread absent**: B-S gives mid-price. Real options have 5-30% bid/ask spreads for liquid names, wider for illiquid. Impact: overstates realized P&L. **Mitigation**: Apply a flat 10% haircut to all theoretical credits and a 10% markup to all theoretical debits.
+
+3. **Early exercise ignored (European B-S for American options)**: Impact: underprices deep ITM American puts. Magnitude: small for OTM options (which is where most structures in this system operate).
+
+4. **Discrete dividends ignored**: Impact: affects call pricing around ex-dates. **Mitigation**: Exclude bars within 5 days of known ex-dividend dates, or adjust S_t by expected dividend.
+
+5. **No term structure**: Using a single vol number for all expiries. Real IV varies by DTE. Impact: misprices calendar spreads (which are out of scope) but also affects DTE-dependent structures.
+
+**Synthetic backtest loop**:
+
+```python
+for each bar t in backtest_period:
+    # 1. Get ktrdr signal
+    ktrdr_signal = ktrdr_model.predict(features_t)  # from existing BacktestingEngine feature cache
+    
+    # 2. Get Kronos vol regime
+    kronos_regime = kronos_classifier.predict(kronos_embedding_t)  # from pre-computed cache
+    
+    # 3. Get IV context
+    iv_rank_t = compute_iv_rank(vix_history, t)
+    
+    # 4. Decision matrix → structure selection
+    structure = decision_matrix(ktrdr_signal, kronos_regime, iv_rank_t)
+    
+    # 5. If structure != NO_TRADE and confidence gates pass:
+    #    a. Select strikes using B-S delta calculation
+    #    b. Compute entry price using B-S
+    #    c. Apply bid/ask haircut
+    #    d. Record position with entry price, strikes, expiry
+    
+    # 6. For each open position:
+    #    a. Mark to market using B-S at current S_t, updated sigma_t, reduced T
+    #    b. Check exit conditions:
+    #       - Take profit: P&L > 50% of max profit (for credit spreads)
+    #       - Stop loss: P&L < -100% of credit received (i.e., max loss hit)
+    #       - Time exit: DTE < 7 (close to avoid gamma risk)
+    #       - Signal reversal: ktrdr signal flips direction
+    #    c. If exit: compute exit P&L with bid/ask haircut
+    
+    # 7. Record equity curve, trade log
+```
+
+**Sharpe threshold for paper trading**: Sharpe > 0.50 on the synthetic backtest across at least 2 years of data, with > 50 trades. If the system produces < 50 trades in 2 years, the thresholds are too restrictive and should be loosened before concluding the strategy doesn't work.
+
+**[VALIDATE EMPIRICALLY]**: The bid/ask haircut of 10% is a guess. If OptionsDX data is acquired, calibrate the haircut against real bid/ask spreads.
+
+### Interaction with Existing BacktestingEngine
+
+The options backtester is a **separate system** from ktrdr's existing `BacktestingEngine` (`ktrdr/backtesting/engine.py`). It is NOT an extension or wrapper.
+
+**Why not extend the existing engine?**:
+- The existing engine tracks stock positions (long/short with linear P&L). Options have nonlinear payoffs, Greeks, time decay, and multi-leg structure management — fundamentally different position semantics.
+- The existing engine uses `PositionManager` (`ktrdr/backtesting/position_manager.py`) with commission and slippage models designed for stocks. Options have different cost structures (per-contract fees, different slippage characteristics).
+- Modifying the existing engine risks breaking the stock backtesting pipeline, which is production-grade and well-tested (~29 test files).
+
+**What it DOES reuse from ktrdr**:
+- **Feature computation**: The options backtester calls ktrdr's feature pipeline (indicators + fuzzy + neural network) to produce directional signals for each bar. It can reuse the same feature cache that the existing `BacktestingEngine` builds.
+- **OHLCV data**: Loaded from ktrdr's data layer (`data/{timeframe}/{Symbol}_{Timeframe}.csv`).
+- **Signal generation**: Uses `DecisionFunction` (`ktrdr/backtesting/decision_function.py`) to produce `TradingDecision` for each bar, identical to how the existing engine does it.
+
+**What is new**:
+- Options position model (tracks each leg: strike, type, DTE, entry price, current Greeks)
+- Black-Scholes pricing engine
+- Structure-specific entry/exit logic
+- Options-specific performance metrics (additional to standard Sharpe/drawdown: average theta, average delta exposure, gamma risk events)
+
+---
+
+## 6. Data Requirements
+
+### Historical OHLCV (already available)
+
+**Source**: ktrdr's data layer at `data/{timeframe}/{Symbol}_{Timeframe}.csv`
+**Format**: CSV with DatetimeIndex (UTC, ISO 8601), columns: `[open, high, low, close, volume]`
+**Compatibility**: Fully compatible. Kronos also accepts OHLCV DataFrames with the same column names (plus optional `amount`). ktrdr's `LocalDataLoader` (`ktrdr/data/local_data_loader.py`, `load()` method, line 171) returns the exact format needed.
+
+**Required data range**: At least 3 years for meaningful options backtesting:
+- 1 year for Kronos classifier training
+- 2 years for out-of-sample options backtest
+- Additional data for IV rank computation (252-day lookback)
+
+**[KARL INPUT NEEDED]**: Which symbols to start with? Recommendation: SPY (most liquid options, VIX is directly applicable) and one single-name stock from ktrdr's existing trained models.
+
+### Historical Implied Volatility Data
+
+**For SPY/SPX (free path)**:
+- VIX daily close from yfinance: `yfinance.download("^VIX", start=..., end=...)`
+- Available from 1990 to present
+- This IS the implied volatility of SPX options (specifically, 30-day ATM IV)
+
+**For single names (paid path)**:
+- OptionsDX: Historical EOD options data includes IV per strike/expiry
+- CBOE LiveVol: Provides historical IV surface data
+- `[KARL INPUT NEEDED]`: Budget and priority for single-name IV data
+
+**IV rank computation**:
+```python
+def iv_rank(iv_current: float, iv_history_252d: pd.Series) -> float:
+    """IV Rank = (current - 252d low) / (252d high - 252d low) * 100"""
+    iv_min = iv_history_252d.min()
+    iv_max = iv_history_252d.max()
+    if iv_max == iv_min:
+        return 50.0
+    return (iv_current - iv_min) / (iv_max - iv_min) * 100
+```
+
+### Options Chain Data
+
+**For backtesting (Phase 2)**: Not strictly needed if using Black-Scholes reconstruction. The system synthesizes option prices from underlying + VIX + risk-free rate.
+
+**For paper/live trading (Phase 3+)**: Real options chain from IBKR:
+- Available strikes and expiries
+- Bid/ask for each contract
+- Current IV per contract
+- Open interest and volume
+- Greeks (IBKR provides these)
+
+**[ASSUMPTION]**: IBKR paper trading provides the same options chain data as live. This needs verification but is generally true for IBKR.
+
+### Label Data for Kronos Vol Regime Classifier
+
+**Constructed from**:
+1. Historical IV: VIX daily (free) or single-name IV (paid)
+2. Historical realized volatility: Computed from ktrdr's OHLCV data
+
+```python
+def compute_realized_vol(prices: pd.Series, window: int = 20) -> pd.Series:
+    """Annualized realized volatility from close prices."""
+    log_returns = np.log(prices / prices.shift(1))
+    return log_returns.rolling(window).std() * np.sqrt(252)
+
+def construct_vol_regime_labels(
+    iv_series: pd.Series,        # daily IV (e.g., VIX/100)
+    prices: pd.Series,           # daily close prices
+    forward_window: int = 20,    # days to compute forward RV
+    iv_rank_high: float = 70,    # percentile for SELL_VOL
+    iv_rank_low: float = 30,     # percentile for BUY_VOL
+    rv_discount: float = 0.85,   # RV < IV * discount = SELL_VOL
+    rv_premium: float = 1.15,    # RV > IV * premium = BUY_VOL
+) -> pd.Series:
+    """Returns labels: 0=NEUTRAL, 1=SELL_VOL, 2=BUY_VOL."""
+    iv_rank = compute_iv_rank_rolling(iv_series, 252)
+    rv_forward = compute_realized_vol(prices, forward_window).shift(-forward_window)
+    
+    labels = pd.Series(0, index=prices.index)  # default NEUTRAL
+    sell_vol_mask = (iv_rank > iv_rank_high) & (rv_forward < iv_series * rv_discount)
+    buy_vol_mask = (iv_rank < iv_rank_low) & (rv_forward > iv_series * rv_premium)
+    labels[sell_vol_mask] = 1  # SELL_VOL
+    labels[buy_vol_mask] = 2  # BUY_VOL
+    
+    return labels
+```
+
+**[ASSUMPTION]**: Using 20-day forward realized vol. This matches the ~30-day options DTE target. The exact forward window should be tested: 10, 15, 20, 30 days.
+
+**Label distribution estimate**: On typical equity indices (SPY), expect roughly 15-25% SELL_VOL, 10-20% BUY_VOL, 55-75% NEUTRAL. The class imbalance needs handling — focal loss or class-weighted cross-entropy.
+
+### Risk-Free Rate
+
+**Source**: Federal Reserve (FRED) — 3-month Treasury bill rate
+**Access**: Free via `pandas_datareader` or FRED API
+**Usage**: Input to Black-Scholes formula; typically 0-5% annualized
+
+---
+
+## 7. Integration Points with ktrdr
+
+### Lux → ktrdr REST API
+
+**Endpoint**: `POST /api/v1/models/predict`
+
+**Request** (from `ktrdr/api/endpoints/models.py`, `PredictionRequest`):
+```json
+{
+    "model_name": "trend_tb_lstm_signal_v1",
+    "symbol": "SPY",
+    "timeframe": "1h",
+    "test_date": "2026-04-18T14:30:00"
+}
+```
+
+- `model_name`: Must match a trained model in `models/{strategy_name}/{timeframe}_v{N}/`
+- `symbol`: Must have OHLCV data in `data/{timeframe}/`
+- `timeframe`: Must be one of ktrdr's supported timeframes (1m, 5m, 15m, 30m, 1h, 4h, 1d, 1w)
+- `test_date`: Optional. If omitted, uses the latest available bar.
+
+**Response**:
+```json
+{
+    "success": true,
+    "model_name": "trend_tb_lstm_signal_v1",
+    "symbol": "SPY",
+    "test_date": "2026-04-18T14:30:00",
+    "prediction": {
+        "signal": "BUY",
+        "confidence": 0.756,
+        "signal_strength": 0.694
+    },
+    "input_features": {
+        "1h_rsi_momentum_oversold": 0.02,
+        "1h_rsi_momentum_neutral": 0.15,
+        "1h_rsi_momentum_overbought": 0.83
+    }
+}
+```
+
+**Missing: full probability distribution**. The response currently lacks `nn_probabilities: {"BUY": 0.756, "HOLD": 0.182, "SELL": 0.062}`. This field exists in the internal `TradingDecision.reasoning` dict but is not surfaced through the API.
+
+**Required API change** (small):
+- In `ktrdr/api/endpoints/models.py`, extend `PredictionResponse` to include `probabilities: dict[str, float]`
+- In the prediction endpoint handler, pass through the `nn_probabilities` from the decision engine's reasoning dict
+
+### ktrdr Server: Running Permanently or On-Demand?
+
+**[KARL INPUT NEEDED]**: Two options:
+
+1. **Persistent** (recommended): ktrdr server runs 24/7 alongside Lux on the same machine. Lux calls `localhost:8000/api/v1/models/predict`. Startup overhead is ~2-5 seconds (model loading), but this is paid once.
+
+2. **On-demand**: Lux starts ktrdr server before each analysis cycle, waits for it to be ready, makes the prediction call, then shuts it down. Adds latency and complexity. Only justified if memory is extremely constrained.
+
+**[ASSUMPTION]**: Using option 1 (persistent server). ktrdr's FastAPI server is lightweight — the main memory cost is the loaded neural network model(s), which are small (MLP: <1MB, LSTM/GRU: <10MB).
+
+### Options Backtester ↔ Existing BacktestingEngine
+
+The options backtester is **separate** from the existing `BacktestingEngine`. The interaction is:
+
+```
+Shared:
+  - OHLCV data (from ktrdr's data layer)
+  - Feature computation (reuse IndicatorEngine + FuzzyEngine + FuzzyNeuralProcessor)
+  - DecisionFunction (for generating ktrdr directional signals per bar)
+  - Model loading (via ModelBundle)
+
+Separate:
+  - Position tracking (options vs stocks)
+  - P&L computation (Black-Scholes vs linear)
+  - Performance metrics (options-specific additions)
+  - Exit logic (theta decay, gamma risk vs simple stop-loss)
+```
+
+The options backtester imports and uses ktrdr's feature pipeline as a library:
+
+```python
+from ktrdr.backtesting.decision_function import DecisionFunction
+from ktrdr.backtesting.model_bundle import ModelBundle
+from ktrdr.indicators.indicator_engine import IndicatorEngine
+from ktrdr.fuzzy.engine import FuzzyEngine
+from ktrdr.training.fuzzy_neural_processor import FuzzyNeuralProcessor
+
+# Use ktrdr's pipeline to generate directional signals
+# Then apply options-specific logic on top
+```
+
+This avoids duplicating ktrdr's feature computation while keeping options logic cleanly separated.
+
+---
+
+## 8. Opus 4.7 Role
+
+### What Input Does Opus 4.7 Receive?
+
+Opus 4.7 receives a structured JSON prompt with all relevant context:
+
+```json
+{
+    "task": "select_options_structure",
+    "timestamp": "2026-04-18T14:30:00Z",
+    "underlying": {
+        "symbol": "SPY",
+        "current_price": 523.45,
+        "price_change_1d": -0.82,
+        "price_change_5d": 1.23
+    },
+    "ktrdr_signal": {
+        "signal": "BUY",
+        "confidence": 0.756,
+        "probabilities": {"BUY": 0.756, "HOLD": 0.182, "SELL": 0.062},
+        "model": "trend_tb_lstm_signal_v1",
+        "timeframe": "1h"
+    },
+    "kronos_regime": {
+        "regime": "SELL_VOL",
+        "confidence": 0.68,
+        "probabilities": {"SELL_VOL": 0.68, "BUY_VOL": 0.12, "NEUTRAL": 0.20}
+    },
+    "vol_context": {
+        "iv_rank": 78.5,
+        "current_iv": 0.22,
+        "vix": 22.4,
+        "rv_20d": 0.17
+    },
+    "options_chain": {
+        "expiries_available": ["2026-04-25", "2026-05-02", "2026-05-16", "2026-06-19"],
+        "relevant_strikes": {
+            "2026-05-16": {
+                "puts": [
+                    {"strike": 515, "bid": 3.20, "ask": 3.45, "iv": 0.21, "delta": -0.22, "oi": 12500},
+                    {"strike": 520, "bid": 5.10, "ask": 5.35, "iv": 0.20, "delta": -0.32, "oi": 18200}
+                ],
+                "calls": [
+                    {"strike": 525, "bid": 4.80, "ask": 5.10, "iv": 0.19, "delta": 0.45, "oi": 15600},
+                    {"strike": 530, "bid": 3.10, "ask": 3.35, "iv": 0.20, "delta": 0.33, "oi": 11300}
+                ]
+            }
+        }
+    },
+    "portfolio_state": {
+        "account_value": 100000,
+        "buying_power": 85000,
+        "open_positions": [],
+        "max_risk_per_trade": 2000
+    },
+    "decision_matrix_suggestion": {
+        "structure": "bull_put_spread",
+        "reasoning": "BUY signal + SELL_VOL regime -> sell premium with directional bias"
+    }
+}
+```
+
+### What Output Does Opus 4.7 Produce?
+
+```json
+{
+    "action": "OPEN",
+    "structure": "bull_put_spread",
+    "legs": [
+        {"type": "SELL", "option_type": "PUT", "strike": 515, "expiry": "2026-05-16", "contracts": 2},
+        {"type": "BUY", "option_type": "PUT", "strike": 510, "expiry": "2026-05-16", "contracts": 2}
+    ],
+    "expected_credit": 1.85,
+    "max_risk": 630,
+    "max_profit": 370,
+    "breakeven": 516.15,
+    "exit_plan": {
+        "take_profit_pct": 50,
+        "stop_loss_pct": 100,
+        "time_exit_dte": 7
+    },
+    "reasoning": "IV rank at 78.5 with BUY signal. Selling put spread collects elevated premium with directional support. Short 515 put at 0.22 delta gives room for pullback. Width of 5 limits max loss to $630 per spread. Two contracts = $1260 max risk within $2000 budget.",
+    "confidence": "HIGH",
+    "warnings": []
+}
+```
+
+### Is Opus 4.7 in the Backtest Hot Path?
+
+**No.** In backtesting, the decision matrix (Section 4) is applied deterministically — there is no Opus 4.7 call. The decision matrix IS the codified version of what Opus 4.7 would recommend.
+
+Opus 4.7 is used only in **live/paper trading**, where:
+- It receives the decision matrix suggestion as a starting point
+- It can override or adjust based on chain-specific nuances (e.g., unusually wide bid/ask on the suggested strikes, better liquidity at adjacent strikes)
+- It provides human-readable reasoning for Karl's review
+- Extended thinking is enabled (latency: 10-30 seconds, which is fine for hourly/daily signals)
+
+**[ASSUMPTION]**: Opus 4.7 is called via the Anthropic API using Lux's existing API key. No separate authentication needed.
+
+### Failure Modes
+
+| Failure | Impact | Mitigation |
+|---------|--------|------------|
+| Opus 4.7 API unavailable (outage, rate limit) | Cannot get reasoning for new trades | Fall back to decision matrix output directly; no Opus override. Log the fallback. |
+| Opus 4.7 returns malformed JSON | Cannot parse trade recommendation | Validate response schema. If invalid after 2 retries, use decision matrix fallback. |
+| Opus 4.7 takes > 60 seconds | Blocks the analysis cycle | Set 60-second timeout. Use decision matrix fallback on timeout. |
+| Opus 4.7 recommends structure outside scope | Could introduce unwanted risk | Validate `structure` field against allowed list. Reject and retry with explicit constraint. |
+| Opus 4.7 sizes position above max risk | Could over-allocate | Validate `max_risk` against `portfolio_state.max_risk_per_trade`. Hard cap enforced by Lux, not by Opus. |
+
+**Critical design principle**: Opus 4.7 is an **advisor**, not a controller. Lux enforces all risk limits. Opus 4.7 cannot bypass position size limits, open disallowed structures, or skip confidence gates. All of its recommendations are validated before execution.
+
+---
+
+## 9. Open Questions / Decisions
+
+### [KARL INPUT NEEDED]
+
+1. **Which symbols to start with?** Recommendation: SPY first (most liquid options, VIX directly applicable). Which single-name stock second?
+
+2. **Budget for historical options data?** $0 (VIX + Black-Scholes reconstruction), ~$200 (OptionsDX for 2-3 symbols), or $1000+ (CBOE DataShop)?
+
+3. **Full probability distribution from ktrdr API**: The current `/predict` endpoint doesn't return `nn_probabilities`. Options: (a) Extend the API endpoint (~10 lines of code), or (b) call ktrdr as a Python library from Lux, bypassing REST. Recommendation: (a).
+
+4. **ktrdr server lifecycle**: Persistent (always running) or on-demand (started per analysis cycle)? Recommendation: persistent.
+
+5. **Max risk per trade**: 2% of account value as default? Karl may have a different risk appetite.
+
+6. **Live trading approval gate**: Should every live trade require Karl's Telegram approval, or only trades above a certain size? Recommendation: require approval for all live trades initially, relax after 30+ successful paper trades.
+
+7. **IBKR MCP options execution API**: I don't know the exact IBKR MCP tool signatures for options order submission. This needs investigation — does the existing IBKR integration in Lux support multi-leg options orders, or only single-leg equity orders?
+
+### [VALIDATE EMPIRICALLY]
+
+1. **Kronos embedding quality for vol classification**: Does AUC > 0.60? This is the central empirical question. If it fails, fall back to IV rank heuristic.
+
+2. **Kronos-mini vs Kronos-small**: Which embedding dimension (256 vs 512) produces better vol regime classification? Start with mini for speed.
+
+3. **Mean pool vs last hidden state**: Which pooling strategy extracts more useful information from Kronos?
+
+4. **Bid/ask haircut calibration**: The 10% flat haircut is a guess. Calibrate against real options data if available.
+
+5. **Optimal DTE for each structure**: The design specifies 14-45 days depending on structure. Backtest should test 14, 21, 30, 45 DTE for each structure type.
+
+6. **Label construction thresholds**: The 70/30 IV rank percentiles and 0.85/1.15 RV/IV multipliers are starting points. Sensitivity analysis needed.
+
+7. **Exit timing**: Take profit at 50% of max profit, or 40%, or 60%? Stop loss at max loss, or earlier at 75%? Backtest should sweep these parameters.
+
+8. **Kronos CPU inference latency**: Expected ~100-500ms on CPU for Kronos-mini. Verify on Karl's Docker stack.
+
+9. **Signal combination method**: The decision matrix is rule-based. An alternative is to train a small model that takes (ktrdr probabilities, Kronos regime probabilities, IV rank) as input and outputs structure probabilities. Start with rules, test learned combination if rules work.
+
+### [ASSUMPTION]
+
+1. **VIX as universal IV proxy**: Using VIX/100 as IV for all underlyings in the $0 backtest path. This is known to be inaccurate for single names. Acceptable for proof-of-concept.
+
+2. **2% max risk per trade**: Conservative baseline. Adjustable.
+
+3. **Opus 4.7 not in backtest hot path**: Decision matrix is applied deterministically in backtests. Opus is only used for live/paper to provide nuanced reasoning.
+
+4. **No position correlation**: Each trade is sized independently. No portfolio-level Greek management in Phase 1.
+
+5. **IBKR paper provides real options chains**: Paper trading account gives the same chain data quality as live. Generally true for IBKR but needs verification.
+
+6. **Kronos frozen embeddings contain vol information**: This is the central hypothesis. If false, the vol regime classifier should be replaced with a simpler approach (e.g., train a small LSTM directly on OHLCV + VIX for vol regime classification, without Kronos).
+
+7. **ktrdr trained models exist for target symbols**: Karl has already trained ktrdr models that produce directional signals for the target symbols. If not, training must happen first.
+
+8. **Lux can call Python functions directly**: Lux can import and run `KronosFeatureProvider` as a Python module, not just via REST API. This avoids needing a separate Kronos microservice.
+
+---
+
+## Appendix A: Glossary
+
+| Term | Definition |
+|------|-----------|
+| **IV Rank** | Current IV's percentile position relative to its 252-day range (0-100) |
+| **DTE** | Days to expiry for an options contract |
+| **ATM** | At-the-money: strike price equal to current underlying price |
+| **OTM** | Out-of-the-money: strike price above (calls) or below (puts) current price |
+| **Delta** | Rate of change of option price with respect to underlying price; also approximates probability of expiring ITM |
+| **Theta** | Rate of time decay of option value per day |
+| **Gamma** | Rate of change of delta; highest near expiry for ATM options |
+| **Vega** | Sensitivity of option price to changes in implied volatility |
+| **RV** | Realized volatility: historical standard deviation of returns, annualized |
+| **B-S** | Black-Scholes option pricing model |
+
+## Appendix B: File References in ktrdr
+
+| Purpose | File | Key Class/Function |
+|---------|------|--------------------|
+| Signal output | `ktrdr/decision/base.py:26` | `TradingDecision` |
+| Signal enum | `ktrdr/decision/base.py:10` | `Signal` |
+| Live inference | `ktrdr/decision/orchestrator.py:216` | `DecisionOrchestrator.make_decision()` |
+| Backtest inference | `ktrdr/backtesting/decision_function.py:50` | `DecisionFunction.__call__()` |
+| Neural network output | `ktrdr/neural/models/base_model.py:57` | `BaseNeuralModel.predict()` |
+| REST prediction | `ktrdr/api/endpoints/models.py:194` | `POST /api/v1/models/predict` |
+| Backtest engine | `ktrdr/backtesting/engine.py:94` | `BacktestingEngine` |
+| Backtest config | `ktrdr/backtesting/engine.py:33` | `BacktestConfig` |
+| Performance metrics | `ktrdr/backtesting/performance.py:36` | `PerformanceMetrics` |
+| Feature pipeline | `ktrdr/training/fuzzy_neural_processor.py:14` | `FuzzyNeuralProcessor` |
+| Feature ordering | `ktrdr/config/feature_resolver.py:35` | `FeatureResolver` |
+| Indicator computation | `ktrdr/indicators/indicator_engine.py:20` | `IndicatorEngine` |
+| Fuzzy membership | `ktrdr/fuzzy/engine.py:28` | `FuzzyEngine` |
+| Data loading | `ktrdr/data/local_data_loader.py:41` | `LocalDataLoader` |
+| Model loading | `ktrdr/backtesting/model_bundle.py:230` | `ModelBundle.load()` |
+| Strategy config schema | `ktrdr/config/models.py:693` | `StrategyConfigurationV3` |
+| Position management | `ktrdr/backtesting/position_manager.py` | `PositionManager` |

--- a/docs/designs/autonomous-options-trading/DESIGN.md
+++ b/docs/designs/autonomous-options-trading/DESIGN.md
@@ -2,7 +2,7 @@
 
 > **Author**: Claude (Opus 4.6), commissioned by Karl Piteira
 > **Date**: 2026-04-18
-> **Status**: Draft v3 — fixes applied for IV metric consistency, backtest/live validation gap, SPY model prerequisite, label frequency calibration
+> **Status**: Draft v4 — fixes applied for problem statement accuracy (ktrdr as research system on forex, not profitable trading system on stocks), equity options (SPY) as target instrument, SPY model training hardened into M1
 > **Grounded in**: ktrdr codebase analysis (`KTRDR_REALITY_MAP.md`), Kronos integration spec (`spec.md`)
 
 ---
@@ -11,18 +11,29 @@
 
 ### What Problem Does This Solve?
 
-Karl has a working directional trading system (ktrdr) with a Sharpe ratio ceiling of 0.181. The system uses hand-crafted technical indicators passed through fuzzy membership functions into a neural network to produce BUY/SELL/HOLD signals. This signal is accurate enough to be profitable on stocks but not enough to justify the capital commitment at meaningful scale.
+ktrdr is a **strategy research system** — not a live trading system. It explores and validates directional trading strategies on **forex pairs** (EUR/USD, GBP/USD, etc.) using a pipeline of technical indicators, fuzzy membership functions, and neural networks (MLP/LSTM/GRU) to produce BUY/SELL/HOLD signals. The pipeline: OHLCV → IndicatorEngine → FuzzyEngine → FuzzyNeuralProcessor → neural network → softmax over {BUY, HOLD, SELL}. ktrdr has **no live trading history** and is **not profitable** — internal validation runs show a Sharpe of approximately 0.181 (from training-period validation, not an independent out-of-sample backtest), a research-grade result that demonstrates directional signal content but not a deployable edge on linear instruments.
 
-**The core insight**: A directional signal with 55-65% accuracy produces mediocre returns on linear stock trades, but the same signal routed through options structures generates asymmetric payoffs. A correct BUY signal that triggers buying a call spread pays 2-5x the risk, while an incorrect signal loses only the premium. Combined with a vol regime signal (from Kronos) that informs *which* options structure to use, the system can match structure to market conditions rather than applying one-size-fits-all directional bets.
+**The opportunity**: ktrdr's backtested directional signals can be extended to **equity options trading**, where options provide asymmetric payoff profiles that can amplify edge even with modest directional accuracy. A correct BUY signal that triggers buying a call spread pays 2-5x the risk, while an incorrect signal loses only the premium paid. Combined with a vol regime signal (from Kronos) that informs *which* options structure to use, the system can match structure to market conditions rather than applying one-size-fits-all directional bets.
+
+**The gap being filled**: ktrdr generates research-grade directional signals but cannot execute or capitalize on them. This system bridges that gap by:
+
+1. Training a new ktrdr model on **SPY** equity data using the same fuzzy-neural pipeline (M1) — transferring the signal methodology from forex to equities
+2. Adding Kronos vol regime classification to determine whether implied volatility is rich or cheap (M1)
+3. Building a Black-Scholes options pricing engine for synthetic backtesting (M2)
+4. Backtesting the full system on SPY options using the decision matrix (M3)
+5. Adding Opus 4.7 reasoning for live trade structure selection and portfolio construction (M4)
+6. Paper trading via IBKR to validate the end-to-end system with real options chains (M5)
+
+**Why equity options, not forex options**: ktrdr's existing models are trained on forex, but the target instrument for this system is **equity options** (SPY as primary underlying). Forex options are OTC, illiquid, and have limited IBKR support — they are explicitly out of scope. Equity options (SPY, etc.) are exchange-traded, liquid, and fully supported by IBKR's API. ktrdr's directional signal methodology transfers to SPY via a new model trained on SPY/equity OHLCV data using the same pipeline.
 
 ### What Does Success Look Like?
 
 | Milestone | Metric | Timeline |
 |-----------|--------|----------|
-| Vol regime signal validates | Kronos classifier AUC > 0.60 on held-out IV data | Phase 1 (weeks 1-2) |
-| Synthetic backtest shows edge | Combined system Sharpe > 0.50 on 2-year synthetic options backtest | Phase 2 (weeks 3-5) |
-| Paper trading confirms | Paper Sharpe > 0.40 over 60+ trading days with > 30 trades | Phase 3 (months 2-4) |
-| Live deployment | Sharpe > 0.35 on real capital, max drawdown < 15% | Phase 4 (month 5+) |
+| M1: SPY model + Vol regime signal validates | ktrdr SPY model trained; Kronos classifier AUC > 0.60 on held-out IV data | Phase 1 (weeks 1-2) |
+| M2: Synthetic backtest shows edge | Combined system Sharpe > 0.50 on 2-year synthetic options backtest | Phase 2 (weeks 3-5) |
+| M3: Paper trading confirms | Paper Sharpe > 0.40 over 60+ trading days with > 30 trades | Phase 3 (months 2-4) |
+| M4: Live deployment | Sharpe > 0.35 on real capital, max drawdown < 15% | Phase 4 (month 5+) |
 
 **The Sharpe targets are deliberately conservative**. A Sharpe of 0.50 on synthetic backtest with Black-Scholes reconstruction has known approximation errors (see Section 5); paper trading at 0.40 accounts for real-world slippage. If these targets are met, the system has genuine edge.
 
@@ -34,6 +45,7 @@ Karl has a working directional trading system (ktrdr) with a Sharpe ratio ceilin
 - **Fully automated execution without human oversight**: Lux recommends trades and can paper-trade autonomously, but live execution requires Karl's approval until paper trading validates the system.
 - **Multi-asset portfolio optimization**: Single-name options on one ticker at a time. Portfolio-level correlation management is out of scope.
 - **Replacing ktrdr's core ML pipeline**: The options layer sits *on top of* ktrdr's existing signal. Phase 1 of Kronos integration (replacing fuzzy features) is specced separately.
+- **Forex options**: OTC, illiquid, limited IBKR support. This system targets exchange-traded equity options only.
 
 ---
 
@@ -88,7 +100,7 @@ Karl has a working directional trading system (ktrdr) with a Sharpe ratio ceilin
 | Component | Responsibility |
 |-----------|---------------|
 | **Lux** | Orchestrates the entire flow: polls ktrdr, runs Kronos, calls Opus 4.7, manages positions, reports via Telegram |
-| **ktrdr REST API** | Produces directional signal (BUY/SELL/HOLD + probability distribution) from existing trained models |
+| **ktrdr REST API** | Produces directional signal (BUY/SELL/HOLD + probability distribution) from trained models. ktrdr is a strategy research system; its signals are backtested research outputs, not live-validated production signals. |
 | **Kronos Vol Regime Classifier** | Classifies current market as SELL_VOL / BUY_VOL / NEUTRAL based on frozen Kronos embeddings + trained linear head |
 | **Options Data Provider** | Supplies IV percentile, options chain data, and historical IV for backtesting |
 | **Signal Aggregation** | Combines ktrdr directional signal, Kronos vol regime, and IV context into a structured decision input |
@@ -100,11 +112,11 @@ Karl has a working directional trading system (ktrdr) with a Sharpe ratio ceilin
 
 1. **Trigger**: Lux runs on a schedule (e.g., every hour for 1h bars, every day for 1d bars) or on demand via Telegram command.
 
-2. **Fetch ktrdr signal**: Lux sends `POST /api/v1/models/predict` to ktrdr server with `{model_name, symbol, timeframe}`. Receives `{signal, confidence, signal_strength}` plus `input_features`.
+2. **Fetch ktrdr signal**: Lux sends `POST /api/v1/models/predict` to ktrdr server with `{model_name, symbol, timeframe}`. Receives `{signal, confidence, signal_strength}` plus `input_features`. Note: ktrdr's signals are research-grade outputs (validation Sharpe ~0.181 on forex, from training runs); the SPY model trained in M1 will have its own validation performance characteristics.
 
 3. **Fetch Kronos vol regime**: Lux calls the Kronos classifier (Python function, not REST — runs in Lux's process or via subprocess). Inputs recent OHLCV bars. Receives `{regime: SELL_VOL|BUY_VOL|NEUTRAL, confidence: float}`.
 
-4. **Fetch options context**: Lux retrieves current IV percentile (from VIX for indices, or from options chain data for single names) and the relevant options chain (strikes, expiries, bid/ask).
+4. **Fetch options context**: Lux retrieves current IV percentile (from VIX for SPY/indices, or from options chain data for single names) and the relevant options chain (strikes, expiries, bid/ask).
 
 5. **Aggregate and call Opus 4.7**: Lux constructs a structured JSON prompt containing the ktrdr signal, Kronos regime, IV data, and options chain. Sends to Opus 4.7 via Anthropic API with extended thinking enabled.
 
@@ -118,7 +130,7 @@ Karl has a working directional trading system (ktrdr) with a Sharpe ratio ceilin
 
 ### Signal 1: ktrdr Directional Signal
 
-**What it encodes**: The probability that the underlying asset will move up (BUY), down (SELL), or stay flat (HOLD) over the model's prediction horizon. This is a supervised classification output trained on historical price movements using triple barrier, zigzag, or forward return labels.
+**What it encodes**: The probability that the underlying asset will move up (BUY), down (SELL), or stay flat (HOLD) over the model's prediction horizon. This is a supervised classification output trained on historical price movements using triple barrier, zigzag, or forward return labels. ktrdr is a strategy research system — these signals are research outputs (validation Sharpe ~0.181 on forex pairs, from training runs), not live-validated production signals.
 
 **How it's produced**: 
 
@@ -131,6 +143,8 @@ The signal originates from ktrdr's neural network (`ktrdr/neural/models/base_mod
 5. Neural network (MLP/LSTM/GRU) produces softmax probabilities over {BUY, HOLD, SELL}
 6. `DecisionOrchestrator` (`ktrdr/decision/orchestrator.py`, lines 216-243) applies position-aware filters
 
+**SPY model (M1 prerequisite)**: ktrdr's existing models are trained on forex pairs (EUR/USD, GBP/USD). M1 must train a new ktrdr model on SPY/equity OHLCV data using the same fuzzy-neural pipeline. This model will produce directional signals for SPY, which gate all downstream milestones (M2 backtest, M3 paper trading). See Section 7 for details.
+
 **How Lux calls it**:
 
 ```
@@ -139,7 +153,7 @@ Content-Type: application/json
 
 {
     "model_name": "trend_tb_lstm_signal_v1",
-    "symbol": "AAPL",
+    "symbol": "SPY",
     "timeframe": "1h",
     "test_date": "2026-04-18T14:30:00"   // optional; defaults to latest bar
 }
@@ -151,7 +165,7 @@ Response (from `ktrdr/api/endpoints/models.py`, `PredictionResponse`, lines 194-
 {
     "success": true,
     "model_name": "trend_tb_lstm_signal_v1",
-    "symbol": "AAPL",
+    "symbol": "SPY",
     "test_date": "2026-04-18T14:30:00",
     "prediction": {
         "signal": "BUY",
@@ -278,6 +292,15 @@ class VolRegimeSignal:
 ---
 
 ## 4. Options Structure Selection Logic
+
+### Target Instrument: Equity Options
+
+This system trades **equity options**, with **SPY** as the primary underlying. The system is designed for equity options generically but is scoped to SPY initially for tractability — SPY has the most liquid options market, VIX is directly applicable as an IV proxy, and it provides a clean single-underlying test case before expanding to other equity options.
+
+**Explicitly NOT in scope**:
+- **Forex options**: OTC, illiquid, limited IBKR support. Although ktrdr's existing models are trained on forex pairs, forex options are not viable for this system.
+- **Plain stock/equity trading**: The system trades options, not the underlying equities directly.
+- **Index options (SPX)**: European-style, cash-settled. SPY options (American-style, share-settled) are preferred for IBKR paper trading compatibility.
 
 ### Decision Matrix
 
@@ -441,7 +464,7 @@ These thresholds are empirical starting points derived from common options tradi
 
 **Objective**: Combine ktrdr directional signal + Kronos vol regime -> select structure -> compute P&L using synthetic options pricing -> measure overall system Sharpe.
 
-**Gate**: ktrdr model trained and validated for target symbol (see [PREREQUISITE] in Section 7).
+**Gate**: ktrdr model trained and validated for SPY (completed in M1 — see Section 7).
 
 #### Options Data Availability
 
@@ -455,7 +478,7 @@ These thresholds are empirical starting points derived from common options tradi
 
 **[KARL INPUT NEEDED]**: Budget for historical options data. Options:
 - **$0 path**: Use VIX + Black-Scholes reconstruction (lower fidelity, but free). Suitable for Phase 2 proof-of-concept.
-- **~$200 path**: OptionsDX data for 2-3 key symbols. Real bid/ask spreads, real IV surface.
+- **~$200 path**: OptionsDX data for SPY. Real bid/ask spreads, real IV surface.
 - **~$1000+ path**: CBOE DataShop for comprehensive coverage.
 
 Recommendation: Start with $0 path (Black-Scholes reconstruction) for Phase 2. If results are promising, validate with OptionsDX data before paper trading.
@@ -498,7 +521,7 @@ where:
               IV_scalar_approx = max(0.8, min(2.0, beta_stock * 0.9 + 0.3))
 ```
 
-**[ASSUMPTION]**: Using VIX as IV proxy for all underlyings is a significant approximation. Single-name IV can deviate substantially from VIX. This is acceptable for proof-of-concept but NOT for production decisions. Paper trading with real IBKR chain data is the true validation.
+**[ASSUMPTION]**: Using VIX as IV proxy for SPY is a close approximation (VIX is derived from SPX options, and SPY tracks SPX). For single names, this is a significant approximation. This is acceptable for proof-of-concept but NOT for production decisions. Paper trading with real IBKR chain data is the true validation.
 
 **Known approximation errors in Black-Scholes reconstruction**:
 
@@ -516,7 +539,7 @@ where:
 
 ```python
 for each bar t in backtest_period:
-    # 1. Get ktrdr signal
+    # 1. Get ktrdr signal (from SPY model trained in M1)
     ktrdr_signal = ktrdr_model.predict(features_t)  # from existing BacktestingEngine feature cache
     
     # 2. Get Kronos vol regime
@@ -585,7 +608,7 @@ The options backtester is a **separate system** from ktrdr's existing `Backtesti
 - 2 years for out-of-sample options backtest
 - Additional data for IV percentile computation (252-day lookback)
 
-**[KARL INPUT NEEDED]**: Which symbols to start with? Recommendation: SPY (most liquid options, VIX is directly applicable) and one single-name stock from ktrdr's existing trained models. **Specific question**: Does a trained ktrdr model already exist for SPY? If not, training one is a prerequisite before M3 (see [PREREQUISITE] in Section 7).
+**SPY OHLCV data**: M1 requires SPY OHLCV data for training the ktrdr SPY model. SPY data is freely available via yfinance and must be loaded into ktrdr's data layer (`data/{timeframe}/SPY_{Timeframe}.csv`) before model training begins.
 
 ### Historical Implied Volatility Data
 
@@ -685,14 +708,29 @@ def build_vol_regime_labels(
 
 ## 7. Integration Points with ktrdr
 
+### M1 Prerequisite: Train ktrdr Model on SPY
+
+**This is a concrete M1 task, not an optional prerequisite.** M1 must include training a ktrdr model on SPY/equity OHLCV data using the existing fuzzy-neural pipeline. This model gates all downstream milestones — without a trained SPY model, the synthetic backtest (M2), paper trading (M3), and all subsequent phases cannot proceed.
+
+**Why this is needed**: ktrdr's existing models are trained on forex pairs (EUR/USD, GBP/USD, etc.). The system trades SPY equity options, so it needs a directional signal trained on SPY data. The same pipeline (OHLCV → IndicatorEngine → FuzzyEngine → FuzzyNeuralProcessor → MLP/LSTM/GRU) is used — only the training data changes.
+
+**M1 training steps**:
+
+1. **Acquire SPY OHLCV data**: Download SPY historical data (minimum 3 years, preferably 5+) via yfinance or other data provider. Load into ktrdr's data layer at `data/{timeframe}/SPY_{Timeframe}.csv`.
+
+2. **Configure strategy**: Create a ktrdr strategy configuration for SPY using the existing `StrategyConfigurationV3` schema. Select indicators, fuzzy sets, and neural network architecture (recommend starting with LSTM, which has performed best on ktrdr's forex models).
+
+3. **Train model**: Use ktrdr's standard training pipeline to train the model. The model will be saved at `models/{strategy_name}/{timeframe}_v{N}/`.
+
+4. **Validate model**: Run ktrdr's `BacktestingEngine` on held-out SPY data. Record Sharpe ratio, accuracy, and signal distribution. The SPY model does not need to exceed the forex model's Sharpe (0.181) — any directional signal content is sufficient for options amplification. However, if the model degenerates to all-HOLD, it is not usable.
+
+5. **Verify API availability**: Confirm the trained model can be loaded and called via `POST /api/v1/models/predict` with `symbol: "SPY"`.
+
+**The model name referenced in this document (`trend_tb_lstm_signal_v1`) is an example** — the actual model name will be determined during M1 training and should be updated in the system configuration.
+
 ### Lux -> ktrdr REST API
 
 **Endpoint**: `POST /api/v1/models/predict`
-
-**[PREREQUISITE — VERIFY BEFORE M3]**: A trained ktrdr model for the target symbol (e.g., SPY) must exist at `models/{strategy_name}/{timeframe}_v{N}/` before the backtest can run. The model name referenced in this document (`trend_tb_lstm_signal_v1`) is an example from the ktrdr API documentation — it is NOT confirmed to be a trained, available model for SPY. If no model exists for SPY:
-- **Option A**: Use ktrdr's existing `BacktestingEngine` to train one (standard ktrdr training pipeline)
-- **Option B**: Use a different symbol where a trained model already exists (e.g., AAPL if a model is trained there)
-- **Do NOT proceed to M3 without confirming this.**
 
 **Request** (from `ktrdr/api/endpoints/models.py`, `PredictionRequest`):
 ```json
@@ -801,7 +839,8 @@ Opus 4.7 receives a structured JSON prompt with all relevant context:
         "confidence": 0.756,
         "probabilities": {"BUY": 0.756, "HOLD": 0.182, "SELL": 0.062},
         "model": "trend_tb_lstm_signal_v1",
-        "timeframe": "1h"
+        "timeframe": "1h",
+        "signal_source": "ktrdr research system — backtested directional signal (SPY model trained in M1)"
     },
     "kronos_regime": {
         "regime": "SELL_VOL",
@@ -922,19 +961,19 @@ The synthetic backtest (Phase 2) validates the **decision matrix only**. The liv
 
 ### [KARL INPUT NEEDED]
 
-1. **Which symbols to start with?** Recommendation: SPY first (most liquid options, VIX directly applicable). Which single-name stock second? **Critical**: Does a trained ktrdr model already exist for SPY? If not, training one is a prerequisite before M3.
+1. **Budget for historical options data?** $0 (VIX + Black-Scholes reconstruction), ~$200 (OptionsDX for SPY), or $1000+ (CBOE DataShop)?
 
-2. **Budget for historical options data?** $0 (VIX + Black-Scholes reconstruction), ~$200 (OptionsDX for 2-3 symbols), or $1000+ (CBOE DataShop)?
+2. **Full probability distribution from ktrdr API**: The current `/predict` endpoint doesn't return `nn_probabilities`. Options: (a) Extend the API endpoint (~10 lines of code), or (b) call ktrdr as a Python library from Lux, bypassing REST. Recommendation: (a).
 
-3. **Full probability distribution from ktrdr API**: The current `/predict` endpoint doesn't return `nn_probabilities`. Options: (a) Extend the API endpoint (~10 lines of code), or (b) call ktrdr as a Python library from Lux, bypassing REST. Recommendation: (a).
+3. **ktrdr server lifecycle**: Persistent (always running) or on-demand (started per analysis cycle)? Recommendation: persistent.
 
-4. **ktrdr server lifecycle**: Persistent (always running) or on-demand (started per analysis cycle)? Recommendation: persistent.
+4. **Max risk per trade**: 2% of account value as default? Karl may have a different risk appetite.
 
-5. **Max risk per trade**: 2% of account value as default? Karl may have a different risk appetite.
+5. **Live trading approval gate**: Should every live trade require Karl's Telegram approval, or only trades above a certain size? Recommendation: require approval for all live trades initially, relax after 30+ successful paper trades.
 
-6. **Live trading approval gate**: Should every live trade require Karl's Telegram approval, or only trades above a certain size? Recommendation: require approval for all live trades initially, relax after 30+ successful paper trades.
+6. **IBKR MCP options execution API**: I don't know the exact IBKR MCP tool signatures for options order submission. This needs investigation — does the existing IBKR integration in Lux support multi-leg options orders, or only single-leg equity orders?
 
-7. **IBKR MCP options execution API**: I don't know the exact IBKR MCP tool signatures for options order submission. This needs investigation — does the existing IBKR integration in Lux support multi-leg options orders, or only single-leg equity orders?
+7. **Additional equity options underlyings**: After SPY is validated, which other equity options to expand to? (e.g., QQQ, IWM, individual large-cap stocks)
 
 ### [VALIDATE EMPIRICALLY]
 
@@ -960,9 +999,11 @@ The synthetic backtest (Phase 2) validates the **decision matrix only**. The liv
 
 11. **Confidence gate sweep**: During M3, sweep `min_ktrdr_confidence` across [0.40, 0.45, 0.50, 0.55]. Select the threshold that maximizes Sharpe while keeping >= 50 trades over 2 years.
 
+12. **SPY model performance**: What Sharpe ratio and signal distribution does the ktrdr model achieve on SPY data? Compare against forex model performance (Sharpe 0.181) as a reference point, but do not gate on exceeding it.
+
 ### [ASSUMPTION]
 
-1. **VIX as universal IV proxy**: Using VIX/100 as IV for all underlyings in the $0 backtest path. This is known to be inaccurate for single names. Acceptable for proof-of-concept.
+1. **VIX as IV proxy for SPY**: Using VIX/100 as IV for SPY is a close approximation (VIX is derived from SPX options). For other equity underlyings, this is less accurate. Acceptable for SPY-focused proof-of-concept.
 
 2. **2% max risk per trade**: Conservative baseline. Adjustable.
 
@@ -974,7 +1015,7 @@ The synthetic backtest (Phase 2) validates the **decision matrix only**. The liv
 
 6. **Kronos frozen embeddings contain vol information**: This is the central hypothesis. If false, the vol regime classifier should be replaced with a simpler approach (e.g., train a small LSTM directly on OHLCV + VIX for vol regime classification, without Kronos).
 
-7. **ktrdr trained models exist for target symbols**: Karl has already trained ktrdr models that produce directional signals for the target symbols. If not, training must happen first (see [PREREQUISITE] in Section 7).
+7. **ktrdr signal methodology transfers from forex to equities**: The same fuzzy-neural pipeline that produces directional signals on forex pairs can produce useful signals on SPY/equity data. This is validated during M1 model training.
 
 8. **Lux can call Python functions directly**: Lux can import and run `KronosFeatureProvider` as a Python module, not just via REST API. This avoids needing a separate Kronos microservice.
 
@@ -984,6 +1025,8 @@ The synthetic backtest (Phase 2) validates the **decision matrix only**. The liv
 
 | Term | Definition |
 |------|-----------|
+| **Target Universe** | **SPY equity options** as the primary instrument. The system is designed for equity options generically but scoped to SPY initially for tractability (most liquid options, VIX directly applicable). Other equity options (QQQ, IWM, large-cap single names) may be added after SPY is validated. Forex options are explicitly out of scope (OTC, illiquid). |
+| **ktrdr** | A **strategy research system** (not a live trading system) that produces directional signals on forex pairs (EUR/USD, GBP/USD) using a fuzzy-neural pipeline. Sharpe ~0.181 from internal validation runs (training-period validation, not independent backtest); no live trading history. |
 | **IV Percentile** | The fraction of days in the trailing 252-day window where IV was lower than today's IV (0-100). A value of 80 means today's IV is higher than 80% of recent days. This is the sole IV-relative metric used in this system — see Section 3 for rationale. |
 | **IV Rank** | An alternative metric (NOT used in this system): `(current - 252d_low) / (252d_high - 252d_low) * 100`. Sensitive to outlier spikes; see Section 3 for why IV Percentile was chosen instead. |
 | **DTE** | Days to expiry for an options contract |

--- a/docs/designs/autonomous-options-trading/IMPLEMENTATION_PLAN.md
+++ b/docs/designs/autonomous-options-trading/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,218 @@
+# ktrdr Autonomous Options Trading System — Implementation Plan
+
+> **Author**: Claude (Opus 4.6), commissioned by Karl Piteira
+> **Date**: 2026-04-18
+> **Status**: Ready for review
+> **Based on**: DESIGN.md (approved), ARCHITECTURE.md (approved)
+
+---
+
+## Executive Summary
+
+This plan implements the ktrdr Autonomous Options Trading System across 5 milestones using a **backtest-first** approach. The system overlays options strategy selection on top of ktrdr's existing directional signals, using Kronos-mini embeddings for volatility regime classification and Opus 4.7 as a live-trading advisor.
+
+The sequence is non-negotiable:
+
+1. **M1 — Kronos Vol Regime Classifier** (8 dev-days): Prove that frozen Kronos-mini embeddings encode vol-relevant information. AUC > 0.60 gate.
+2. **M2 — Black-Scholes Engine + Data Infrastructure** (7 dev-days): Build the synthetic options pricing engine and all supporting data infrastructure.
+3. **M3 — Full Synthetic Backtest Loop** (12 dev-days): Wire everything together — ktrdr signals + Kronos + B-S + decision matrix + position management. Sharpe > 0.50 gate.
+4. **M4 — Live/Paper Infrastructure** (10 dev-days): Build the live analysis pipeline — ktrdr HTTP client, Opus 4.7 advisor, LuxOrchestrator.
+5. **M5 — IBKR Execution + Paper Trading** (8 dev-days): Close the loop with IBKR, run 60-day paper trading. Sharpe > 0.40 gate.
+
+**Total estimated effort: 45 developer-days.**
+
+No milestone may begin until its predecessor's go/no-go gate is passed. No live trading occurs until synthetic and paper trading are validated.
+
+---
+
+## Dependency Graph
+
+```
+M1: Kronos Vol Regime Classifier
+│
+│  Gate: AUC > 0.60
+│
+├──> M2: Black-Scholes + Data Infrastructure
+│    │
+│    │  Gate: B-S prices match textbook references within 1%
+│    │        Put-call parity holds within numerical tolerance
+│    │
+│    └──> M3: Full Synthetic Backtest Loop
+│         │
+│         │  Gate: Sharpe > 0.50, >= 50 trades, max DD < 25%
+│         │
+│         └──> M4: Live/Paper Infrastructure
+│              │
+│              │  Gate: Full cycle < 90s, SQLite writes, Telegram fires
+│              │        Opus fallback works
+│              │
+│              └──> M5: IBKR Execution + Paper Trading
+│                   │
+│                   │  Gate: Live Sharpe > 0.40, >= 30 trades, 60+ days
+│                   │
+│                   └──> PRODUCTION
+```
+
+### Cross-Milestone Dependencies
+
+| Downstream | Requires From Upstream | Details |
+|-----------|----------------------|---------|
+| M2 | M1 | `KronosVolClassifier` class and trained classifier weights |
+| M3 | M1 | Pre-computed Kronos embeddings cache (`.pt` files) |
+| M3 | M2 | `BlackScholesEngine`, `OptionsDataProvider` (VIX history, risk-free rate) |
+| M3 | ktrdr repo | ktrdr installed as Python package (library imports) |
+| M4 | M3 | `OptionsDecisionMatrix`, `OptionsPositionManager`, `SignalAggregator` (reused) |
+| M4 | ktrdr repo | ktrdr API extended with `probabilities` field (~10 lines) |
+| M5 | M4 | Full `LuxOrchestrator`, all components integrated |
+| M5 | IBKR MCP | Multi-leg options order support — `[DECISION NEEDED]` |
+
+---
+
+## Go/No-Go Gates
+
+| Gate | Milestone Exit | Criteria | Fallback if Gate Fails |
+|------|---------------|----------|----------------------|
+| **G1** | M1 → M2 | AUC > 0.60 on held-out test set (2023 data) | Try mean pooling, Kronos-small (512d), adjust label thresholds. If still < 0.55: replace with IV rank heuristic. |
+| **G2** | M2 → M3 | B-S prices match CBOE/textbook within 1%. Put-call parity holds. Greeks signs correct. | Fix implementation bugs. This is pure math — it must pass. |
+| **G3** | M3 → M4 | Sharpe > 0.50 AND >= 50 trades AND max drawdown < 25% on 2022-2024 SPY | Tune confidence thresholds, adjust structure selection, review exit conditions. Sweep DTE, take-profit, stop-loss parameters. |
+| **G4** | M4 → M5 | Full analysis cycle < 90s. SQLite records written. Telegram fires. Matrix fallback works when Opus mocked to fail. | Debug cycle bottlenecks. Usually Opus latency — increase timeout or optimize prompt. |
+| **G5** | M5 → PROD | Live Sharpe > 0.40 over 60+ days AND >= 30 paper trades | Review signal thresholds, adjust exit rules, investigate signal degradation via calibration table. |
+
+---
+
+## Risk Register
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|------|-----------|--------|------------|
+| **R1** | Kronos embeddings do not encode vol information (AUC < 0.55) | Medium | **Critical** — blocks entire system value proposition | IV rank heuristic fallback is pre-built (Design Sec. 3). System still functions, just without ML-enhanced vol classification. Try mean pooling, Kronos-small, adjusted labels before abandoning. |
+| **R2** | Black-Scholes synthetic backtest overfits — real-world performance degrades | Medium | High — false confidence from backtest | 10% bid/ask haircut is conservative. Paper trading (M5) is the true validation. Do NOT increase capital allocation based on synthetic Sharpe alone. |
+| **R3** | IBKR MCP does not support multi-leg options orders (BAG orders) | Medium | Medium — forces sequential leg execution with slippage risk | Validate before M5 starts. If unsupported: implement as sequential legs, add slippage tracking, widen haircut for live mode. |
+| **R4** | ktrdr signal accuracy degrades during paper trading period | Low-Medium | Medium — system opens losing trades | Calibration table (M5) monitors rolling accuracy. Alert fires if ktrdr win rate drops > 20% from backtest baseline. Pause new trades on alert. |
+| **R5** | Opus 4.7 API latency or availability during market hours | Low | Low — matrix fallback handles this seamlessly | Matrix fallback is deterministic and tested in M3. `TradeRecommendation.source="matrix"` tracks fallback frequency. If > 30% fallback rate, investigate. |
+
+---
+
+## ktrdr Changes Required
+
+**File**: `ktrdr/api/endpoints/models.py`
+**Change**: Extend `Prediction` model to include `probabilities` field.
+
+```python
+# In Prediction model (line ~200):
+class Prediction(BaseModel):
+    signal: str
+    confidence: float
+    signal_strength: float
+    probabilities: dict[str, float] | None = None  # NEW
+
+# In prediction endpoint handler (line ~225):
+# After obtaining TradingDecision:
+probabilities = trading_decision.reasoning.get("nn_probabilities")
+prediction = Prediction(
+    signal=trading_decision.signal.value,
+    confidence=trading_decision.confidence,
+    signal_strength=trading_decision.signal_strength,
+    probabilities=probabilities,  # NEW
+)
+```
+
+**Estimated change**: ~5-10 lines. Backward-compatible (field is optional with `None` default).
+**When needed**: M4 (live/paper mode). NOT needed for M1-M3 (backtest uses library imports, not REST).
+
+---
+
+## Package Structure
+
+```
+ktrdr-options/
+├── pyproject.toml                          # Package config, dependencies
+├── ktrdr-options-config.yaml               # Default configuration
+├── README.md
+│
+├── ktrdr_options/
+│   ├── __init__.py
+│   ├── __main__.py                         # CLI entry point
+│   │
+│   ├── signals/
+│   │   ├── __init__.py
+│   │   ├── kronos_classifier.py            # KronosVolClassifier, VolRegimeSignal
+│   │   ├── ktrdr_client.py                 # KtrdrSignalClient, KtrdrSignal
+│   │   └── aggregator.py                   # SignalAggregator, DecisionInput
+│   │
+│   ├── strategy/
+│   │   ├── __init__.py
+│   │   ├── decision_matrix.py              # OptionsDecisionMatrix, StructureType, StructureChoice
+│   │   └── opus_advisor.py                 # OpusStrategyAdvisor, TradeRecommendation, ExitPlan
+│   │
+│   ├── backtest/
+│   │   ├── __init__.py
+│   │   ├── black_scholes.py                # BlackScholesEngine, OptionPrice
+│   │   └── engine.py                       # OptionsBacktestEngine, OptionsBacktestConfig, Results
+│   │
+│   ├── positions/
+│   │   ├── __init__.py
+│   │   ├── position.py                     # OptionsPosition, OptionsLeg, PositionStatus
+│   │   └── manager.py                      # OptionsPositionManager
+│   │
+│   ├── data/
+│   │   ├── __init__.py
+│   │   └── options_data.py                 # OptionsDataProvider, OptionsChain, IVData, OptionContract
+│   │
+│   ├── persistence/
+│   │   ├── __init__.py
+│   │   └── schema.py                       # SQLite schema creation, migration
+│   │
+│   ├── orchestrator.py                     # LuxOrchestrator, CycleResult
+│   │
+│   ├── train_classifier.py                 # CLI: train Kronos vol regime classifier
+│   └── backtest_cli.py                     # CLI: run synthetic backtest
+│
+├── tests/
+│   ├── __init__.py
+│   ├── test_kronos_classifier.py
+│   ├── test_black_scholes.py
+│   ├── test_decision_matrix.py
+│   ├── test_position_manager.py
+│   ├── test_backtest_engine.py
+│   ├── test_ktrdr_client.py
+│   ├── test_opus_advisor.py
+│   ├── test_signal_aggregator.py
+│   ├── test_options_data.py
+│   └── test_orchestrator.py
+│
+├── cache/                                  # Runtime caches (gitignored)
+│   ├── kronos/                             # Pre-computed embeddings
+│   └── vix_daily.csv                       # Cached VIX history
+│
+├── models/                                 # Trained model weights (gitignored)
+│   └── kronos_classifier/
+│       ├── SPY_head.pt                     # Trained classifier head
+│       └── config.json                     # Classifier config
+│
+└── logs/                                   # Runtime logs (gitignored)
+    └── ktrdr_options.log
+```
+
+---
+
+## Milestone Summary
+
+| Milestone | Effort | Key Deliverable | Gate |
+|-----------|--------|----------------|------|
+| M1: Kronos Vol Regime Classifier | 8 days | Trained classifier, AUC report | AUC > 0.60 |
+| M2: Black-Scholes + Data | 7 days | Pricing engine, data providers | B-S validation |
+| M3: Full Backtest Loop | 12 days | End-to-end backtest, trade log | Sharpe > 0.50 |
+| M4: Live/Paper Infrastructure | 10 days | Opus advisor, orchestrator | Cycle < 90s |
+| M5: IBKR + Paper Trading | 8 days | 60-day paper trading results | Sharpe > 0.40 |
+| **Total** | **45 days** | | |
+
+---
+
+## Open Decisions Requiring Karl's Input
+
+1. **`[DECISION NEEDED]` Symbols**: SPY first. Which single-name stock second?
+2. **`[DECISION NEEDED]` Historical options data budget**: $0 (B-S reconstruction), ~$200 (OptionsDX), or $1000+ (CBOE)?
+3. **`[DECISION NEEDED]` ktrdr API extension**: Extend `/predict` to return `probabilities` (~10 lines). Recommended over library-direct approach.
+4. **`[DECISION NEEDED]` Live trading approval gate**: All live trades require Telegram approval initially?
+5. **`[DECISION NEEDED]` IBKR MCP options capabilities**: Does the existing integration support multi-leg combo (BAG) orders?
+6. **`[DECISION NEEDED]` Max risk per trade**: 2% default — adjust?

--- a/docs/designs/autonomous-options-trading/milestones/MILESTONE_1.md
+++ b/docs/designs/autonomous-options-trading/milestones/MILESTONE_1.md
@@ -1,0 +1,268 @@
+# Milestone 1: Kronos Vol Regime Classifier
+
+---
+
+## A. Objective
+
+Train and validate a linear classifier head on frozen Kronos-mini (4.1M params, 256-dim) embeddings that classifies the current market volatility regime as SELL_VOL, BUY_VOL, or NEUTRAL. This milestone proves or disproves the central hypothesis: that Kronos hidden states encode vol-relevant information extractable by a simple linear probe. AUC > 0.60 on held-out 2023 test data is the mandatory gate — if it fails, the system falls back to a rule-based IV rank heuristic, and Kronos integration is deprioritized.
+
+---
+
+## B. Go/No-Go Gate (from previous milestone)
+
+**Entry gate**: None — this is the first milestone.
+
+**Prerequisites**:
+- Python 3.12 environment with PyTorch available
+- Internet access for HuggingFace model download and yfinance data fetch
+- Sufficient disk space for Kronos-mini weights (~50MB) and embedding cache (~100MB)
+
+---
+
+## C. Files to Create (proposed paths)
+
+| # | File Path | Purpose | Key Classes/Functions |
+|---|-----------|---------|----------------------|
+| 1 | `ktrdr-options/pyproject.toml` | Python package definition, dependencies | N/A (config) |
+| 2 | `ktrdr-options/ktrdr_options/__init__.py` | Package init | Version string |
+| 3 | `ktrdr-options/ktrdr_options/signals/__init__.py` | Signals subpackage init | Exports |
+| 4 | `ktrdr-options/ktrdr_options/signals/kronos_classifier.py` | Kronos vol regime classifier | `KronosVolClassifier`, `VolRegimeSignal`, `REGIME_LABELS` |
+| 5 | `ktrdr-options/ktrdr_options/data/__init__.py` | Data subpackage init | Exports |
+| 6 | `ktrdr-options/ktrdr_options/data/label_builder.py` | Vol regime label construction pipeline | `build_vol_regime_labels()`, `compute_iv_rank_rolling()`, `compute_realized_vol()`, `download_spy_ohlcv()`, `download_vix_history()` |
+| 7 | `ktrdr-options/ktrdr_options/train_classifier.py` | CLI: train and evaluate classifier | `main()`, `train()`, `evaluate()`, `generate_report()` |
+| 8 | `ktrdr-options/tests/__init__.py` | Test package init | N/A |
+| 9 | `ktrdr-options/tests/test_kronos_classifier.py` | Unit tests for classifier | `TestKronosVolClassifier` |
+| 10 | `ktrdr-options/tests/test_label_builder.py` | Unit tests for label construction | `TestLabelBuilder` |
+
+---
+
+## D. Files to Modify (in ktrdr repo)
+
+None. Milestone 1 does not require any changes to the ktrdr codebase. The options classifier is a standalone component.
+
+---
+
+## E. Implementation Tasks
+
+### Task 1: Set up `ktrdr-options` Python package structure
+- Create `ktrdr-options/pyproject.toml` with dependencies: `torch>=2.0`, `einops==0.8.1`, `huggingface_hub>=0.20`, `safetensors>=0.4`, `yfinance>=0.2`, `scikit-learn>=1.3`, `pandas>=2.0`, `numpy>=1.24`
+- Create package directories: `ktrdr_options/`, `ktrdr_options/signals/`, `ktrdr_options/data/`, `tests/`
+- Create `__init__.py` files with appropriate exports
+- Verify: `pip install -e ktrdr-options/` succeeds and `import ktrdr_options` works
+- **Test**: `python -c "import ktrdr_options; print(ktrdr_options.__version__)"` succeeds
+
+### Task 2: Download and validate Kronos-mini from HuggingFace
+- In `KronosVolClassifier.__init__()`: accept `kronos_model_name="NeoQuasar/Kronos-mini"` and `tokenizer_name="NeoQuasar/Kronos-Tokenizer-2k"`
+- In `KronosVolClassifier.load_model()`:
+  - Download model weights via `huggingface_hub.hf_hub_download()` or direct model loading
+  - Load Kronos-mini model with frozen weights (`requires_grad_(False)`)
+  - Load KronosTokenizer
+  - Verify model has expected embedding dimension (256)
+  - Set `self._is_loaded = True`
+- Handle errors: `FileNotFoundError` if no internet, `RuntimeError` if weights corrupted
+- **Test**: Load model, verify `sum(p.numel() for p in model.parameters())` matches expected ~4.1M params, verify all params have `requires_grad=False`
+
+### Task 3: Implement `KronosVolClassifier.extract_embedding()`
+- **File**: `ktrdr_options/signals/kronos_classifier.py`
+- **Method**: `extract_embedding(self, ohlcv: pd.DataFrame) -> torch.Tensor`
+- Input: `pd.DataFrame` with OHLCV columns, at least 50 rows, uses last 512 rows if longer
+- Process:
+  1. Validate input columns: `[open, high, low, close, volume]`
+  2. Tokenize OHLCV via KronosTokenizer
+  3. Forward pass through frozen Kronos-mini: `with torch.no_grad():`
+  4. Extract hidden states: shape `(batch, seq_len, 256)`
+  5. Pool according to `self._pooling`:
+     - `"last"`: take `hidden_states[:, -1, :]` → shape `(1, 256)`
+     - `"mean"`: take `hidden_states.mean(dim=1)` → shape `(1, 256)`
+- Output: `torch.Tensor` shape `(1, 256)`
+- **Test**: Assert output shape `(1, 256)`, assert weights don't change after call (`torch.equal` on params before/after), assert deterministic output for same input (run twice, compare)
+
+### Task 4: Implement `KronosVolClassifier.extract_embeddings_batched()`
+- **File**: `ktrdr_options/signals/kronos_classifier.py`
+- **Method**: `extract_embeddings_batched(self, ohlcv: pd.DataFrame, window_size: int = 512, stride: int = 1) -> torch.Tensor`
+- Sliding window over full historical OHLCV DataFrame
+- For each window position `i` from `window_size` to `len(ohlcv)` with step `stride`:
+  - Extract `ohlcv[i-window_size:i]`
+  - Call `extract_embedding()` (or batch multiple windows for efficiency)
+- Output: `torch.Tensor` shape `(num_windows, 256)`
+- Save progress periodically (every 100 windows) to allow resume on interruption
+- **Test**: Given 1000-row DataFrame with window_size=512, stride=1: assert output shape `(489, 256)`. Assert output is deterministic.
+
+### Task 5: Build the label construction pipeline
+- **File**: `ktrdr_options/data/label_builder.py`
+- **Function**: `download_spy_ohlcv(start: str, end: str) -> pd.DataFrame`
+  - Download SPY daily OHLCV from yfinance
+  - Return DataFrame with DatetimeIndex, columns `[open, high, low, close, volume]`
+- **Function**: `download_vix_history(start: str, end: str) -> pd.Series`
+  - Download VIX daily close from yfinance (`^VIX`)
+  - Return Series with DatetimeIndex
+- **Function**: `compute_iv_rank_rolling(iv_series: pd.Series, lookback: int = 252) -> pd.Series`
+  - For each date, compute percentile rank of current IV within trailing 252-day window
+  - Return Series with values 0-100
+- **Function**: `compute_realized_vol(prices: pd.Series, window: int = 20) -> pd.Series`
+  - `log_returns.rolling(window).std() * sqrt(252)`
+  - Return annualized RV series
+- **Function**: `build_vol_regime_labels(iv_series, prices, iv_rank_high=70, iv_rank_low=30, rv_discount=0.85, rv_premium=1.15, forward_window=20) -> pd.Series`
+  - Compute IV rank from `iv_series`
+  - Compute forward realized vol from `prices` (shifted by `-forward_window`)
+  - Assign labels: 0=NEUTRAL, 1=SELL_VOL, 2=BUY_VOL per Design Sec. 3 rules
+  - Drop last `forward_window` rows (no future data available)
+  - Return integer Series
+- **Test**: 
+  - `compute_iv_rank_rolling`: given synthetic IV series [10, 20, 30], verify ranks are correct
+  - `compute_realized_vol`: given constant prices, verify RV = 0
+  - `build_vol_regime_labels`: verify no look-ahead bias (label at time t only uses prices up to t for IV rank, and forward prices for RV), verify label distribution is reasonable (expect 55-75% NEUTRAL)
+
+### Task 6: Pre-compute and cache all Kronos embeddings
+- **File**: `ktrdr_options/train_classifier.py` (or callable from it)
+- Download SPY OHLCV 2022-01-01 to 2024-01-01 (via `download_spy_ohlcv()`)
+- Call `KronosVolClassifier.extract_embeddings_batched()` on full dataset
+- Save embeddings to `cache/kronos/SPY_1d_embeddings.pt`
+- Save metadata: `{symbol, timeframe, start_date, end_date, window_size, stride, num_embeddings, embedding_dim}`
+- Log progress: "Extracting embeddings: {i}/{total}"
+- `[VALIDATE EMPIRICALLY]`: Measure CPU inference latency per window (expected ~100-500ms)
+- **Test**: Load saved `.pt` file, verify shape matches expected `(num_windows, 256)`, verify metadata matches
+
+### Task 7: Train `Linear(256 -> 3)` classifier head
+- **File**: `ktrdr_options/signals/kronos_classifier.py`
+- **Method**: `KronosVolClassifier.train_classifier(embeddings, labels, val_embeddings, val_labels, epochs=100, lr=0.001, class_weights=[1.0, 2.0, 2.5])`
+- Initialize `nn.Linear(256, 3)` classifier head
+- Optimizer: Adam with `lr=0.001`
+- Loss: `nn.CrossEntropyLoss(weight=torch.tensor([1.0, 2.0, 2.5]))` — upweight rare SELL_VOL and BUY_VOL classes
+- Training loop:
+  1. Forward pass: `logits = self._classifier(embeddings)`
+  2. Compute loss
+  3. Backward + step
+  4. Every epoch: compute validation loss and AUC
+  5. Early stopping: patience=10 epochs on val loss
+- Chronological train/val/test split: train=2022, val=Jan-Jun 2023, test=Jul-Dec 2023
+- Return dict: `{"train_loss", "val_loss", "val_auc", "val_accuracy", "per_class_precision", "per_class_recall"}`
+- **Test**: Train on synthetic embeddings (random) with known labels. Verify loss decreases over epochs. Verify early stopping triggers when val loss plateaus.
+
+### Task 8: Evaluate classifier — AUC, confusion matrix, label distribution
+- **File**: `ktrdr_options/train_classifier.py`
+- **Function**: `evaluate(classifier, test_embeddings, test_labels) -> dict`
+- Compute:
+  - AUC per class (one-vs-rest) using `sklearn.metrics.roc_auc_score` with `multi_class="ovr"`
+  - Macro-averaged AUC
+  - Confusion matrix via `sklearn.metrics.confusion_matrix`
+  - Per-class precision and recall
+  - Label distribution: count and percentage per class
+- Compare against IV rank heuristic baseline: compute same metrics using `iv_rank > 70 = SELL_VOL, < 30 = BUY_VOL, else NEUTRAL`
+- Print formatted report to stdout
+- **Test**: Given perfect predictions, verify AUC = 1.0. Given random predictions, verify AUC ~ 0.50.
+- **`[VALIDATE EMPIRICALLY]`**: The AUC > 0.60 gate is checked here.
+
+### Task 9: Implement `KronosVolClassifier.predict()` with IV rank heuristic fallback
+- **File**: `ktrdr_options/signals/kronos_classifier.py`
+- **Method**: `predict(self, ohlcv: pd.DataFrame, iv_rank: float, timestamp: str | None = None) -> VolRegimeSignal`
+- If classifier is loaded (`self._classifier` weights loaded):
+  1. Call `extract_embedding(ohlcv)` → embedding
+  2. Forward through classifier: `logits = self._classifier(embedding)`
+  3. Softmax → probabilities: `{"SELL_VOL": float, "BUY_VOL": float, "NEUTRAL": float}`
+  4. `regime = REGIME_LABELS[argmax]`, `confidence = max(probabilities)`
+- If classifier NOT loaded (fallback):
+  - `regime = "SELL_VOL" if iv_rank > 70 else "BUY_VOL" if iv_rank < 30 else "NEUTRAL"`
+  - `confidence = 0.6` (fixed — heuristic has no calibrated confidence)
+  - `probabilities` set accordingly
+- Return `VolRegimeSignal(regime, confidence, probabilities, iv_rank, timestamp)`
+- **Test**: With trained classifier, verify output regime matches expected for known embedding. Verify fallback works when `classifier_weights_path=None`. Verify timestamp defaults to current time.
+
+### Task 10: Implement persistence — save/load classifier head weights
+- **File**: `ktrdr_options/signals/kronos_classifier.py`
+- **Method**: `save_classifier(self, path: str) -> None`
+  - Save `self._classifier.state_dict()` to `{path}/head.pt`
+  - Save config to `{path}/config.json`: `{embedding_dim, num_classes, pooling, kronos_model_name}`
+- **Method**: `load_classifier(self, path: str) -> None`
+  - Load config from `{path}/config.json`
+  - Verify `embedding_dim` matches
+  - Load `self._classifier.load_state_dict()` from `{path}/head.pt`
+- **Test**: Save classifier, load into new instance, verify predictions match original on same input.
+
+### Task 11: Write CLI entry point
+- **File**: `ktrdr_options/train_classifier.py`
+- **Function**: `main()`
+- CLI: `python -m ktrdr_options.train_classifier --symbol SPY --start 2022-01-01 --end 2024-01-01 [--pooling last|mean] [--output-dir models/kronos_classifier]`
+- Full pipeline:
+  1. Download OHLCV and VIX data
+  2. Build labels
+  3. Load/compute Kronos embeddings (with caching)
+  4. Split chronologically: train/val/test
+  5. Train classifier
+  6. Evaluate on test set
+  7. Print report with AUC, confusion matrix, comparison to IV rank baseline
+  8. Save classifier weights if AUC > 0.60
+  9. Exit with code 0 if AUC > 0.60, code 1 otherwise
+- **Test**: Run CLI end-to-end with `--start 2023-01-01 --end 2023-06-01` (small dataset for speed). Verify it produces output files and prints evaluation report.
+
+---
+
+## F. Acceptance Criteria
+
+### Unit Tests
+- [ ] `KronosVolClassifier.load_model()` successfully loads Kronos-mini, all 4.1M params frozen
+- [ ] `extract_embedding()` produces deterministic `(1, 256)` tensor for same input
+- [ ] `extract_embedding()` does not modify Kronos model weights
+- [ ] `extract_embeddings_batched()` produces correct shape for given input length and stride
+- [ ] `train_classifier()` reduces training loss over epochs
+- [ ] `train_classifier()` triggers early stopping when validation loss plateaus
+- [ ] `predict()` returns valid `VolRegimeSignal` with correct fields
+- [ ] `predict()` falls back to IV rank heuristic when classifier weights not loaded
+- [ ] `save_classifier()` / `load_classifier()` round-trips correctly
+- [ ] `build_vol_regime_labels()` produces no NaN values (after dropping forward window)
+- [ ] `build_vol_regime_labels()` label distribution has NEUTRAL as majority class
+- [ ] `compute_iv_rank_rolling()` returns values in 0-100 range
+
+### Integration Tests
+- [ ] Full pipeline: download data → build labels → compute embeddings → train → evaluate runs end-to-end
+- [ ] CLI `python -m ktrdr_options.train_classifier` executes without error
+- [ ] Saved classifier weights can be loaded in a fresh Python process and produce predictions
+
+### Empirical Validation Gates
+- [ ] **`[VALIDATE EMPIRICALLY]`** AUC > 0.60 on held-out test set (Jul-Dec 2023 data)
+- [ ] **`[VALIDATE EMPIRICALLY]`** Kronos classifier beats IV rank heuristic baseline on AUC
+- [ ] **`[VALIDATE EMPIRICALLY]`** Per-class precision > 0.40 for both SELL_VOL and BUY_VOL
+- [ ] **`[VALIDATE EMPIRICALLY]`** Kronos-mini CPU inference latency < 1s per window
+
+### Performance Requirements
+- [ ] Embedding extraction: < 1 second per window on CPU
+- [ ] Full training pipeline (2 years SPY data): < 30 minutes total
+- [ ] Classifier inference (single prediction): < 10ms (after embedding extraction)
+
+---
+
+## G. Estimated Effort
+
+**8 developer-days**
+
+| Task | Days |
+|------|------|
+| Package setup (Task 1) | 0.5 |
+| Kronos model loading (Task 2) | 1.0 |
+| Embedding extraction (Tasks 3-4) | 1.5 |
+| Label construction pipeline (Task 5) | 1.0 |
+| Pre-compute + cache embeddings (Task 6) | 0.5 |
+| Classifier training (Task 7) | 1.0 |
+| Evaluation + reporting (Task 8) | 1.0 |
+| Predict + fallback (Task 9) | 0.5 |
+| Persistence + CLI (Tasks 10-11) | 1.0 |
+
+The Kronos model integration (Tasks 2-4) has the most uncertainty — the Kronos API surface may require adaptation. Budget extra time here.
+
+---
+
+## H. Open Questions / Risks
+
+1. **`[VALIDATE EMPIRICALLY]`** Does mean pooling outperform last hidden state? Test both during Task 7 — run training twice with different `pooling` parameter, compare AUC. Default to last hidden state.
+
+2. **`[VALIDATE EMPIRICALLY]`** Does Kronos-small (512-dim) improve AUC enough to justify the extra compute? Only test if Kronos-mini AUC is 0.55-0.60 (borderline).
+
+3. **Kronos API surface**: The Kronos model loading code path needs investigation. The model is on HuggingFace at `NeoQuasar/Kronos-mini`, but the exact Python API for loading and running inference must be validated against the Kronos codebase. The `spec.md` should document this, but verify empirically.
+
+4. **Label quality**: The SELL_VOL/BUY_VOL labels are constructed from the VIX-to-realized-vol relationship. For SPY this is clean (VIX IS the SPY implied vol). For single names, the label quality will be lower. M1 only uses SPY — defer single-name label quality to future work.
+
+5. **Class imbalance**: Expected 55-75% NEUTRAL. The class weights `[1.0, 2.0, 2.5]` are a starting point. If SELL_VOL or BUY_VOL classes have < 10% prevalence, consider focal loss or oversampling.
+
+6. **`[VALIDATE EMPIRICALLY]`** Forward RV window: the design uses 20 days. Test 10, 15, 20, 30 during label construction to find the window that maximizes AUC.
+
+7. **Data availability**: yfinance VIX data must cover the full training period (2022-2024). If yfinance rate-limits or returns gaps, cache data locally after first download.

--- a/docs/designs/autonomous-options-trading/milestones/MILESTONE_2.md
+++ b/docs/designs/autonomous-options-trading/milestones/MILESTONE_2.md
@@ -1,0 +1,254 @@
+# Milestone 2: Black-Scholes Engine + Synthetic Data Infrastructure
+
+---
+
+## A. Objective
+
+Implement the options pricing engine (Black-Scholes with full Greeks) and the data infrastructure required for synthetic backtesting: VIX history, risk-free rate, IV estimation, and synthetic options chain construction. This milestone produces all the mathematical and data machinery needed to price options without live market data, enabling the full backtest loop in M3. No live data or external APIs (beyond VIX/FRED) are required.
+
+---
+
+## B. Go/No-Go Gate (from previous milestone)
+
+**Entry gate from M1**:
+- [ ] Kronos vol regime classifier trained with AUC > 0.60 on held-out test set
+- [ ] Classifier weights saved to `models/kronos_classifier/SPY_head.pt`
+- [ ] Pre-computed Kronos embeddings cached at `cache/kronos/SPY_1d_embeddings.pt`
+- [ ] `ktrdr-options` package structure established and installable
+
+If M1 AUC < 0.60 but > 0.55: proceed with M2 (B-S engine is useful regardless) while tuning Kronos classifier. If AUC < 0.55: proceed with M2 using IV rank heuristic as vol regime signal.
+
+---
+
+## C. Files to Create (proposed paths)
+
+| # | File Path | Purpose | Key Classes/Functions |
+|---|-----------|---------|----------------------|
+| 1 | `ktrdr-options/ktrdr_options/backtest/__init__.py` | Backtest subpackage init | Exports |
+| 2 | `ktrdr-options/ktrdr_options/backtest/black_scholes.py` | Black-Scholes pricing engine with full Greeks | `BlackScholesEngine`, `OptionPrice` |
+| 3 | `ktrdr-options/ktrdr_options/data/options_data.py` | Options data provider (VIX, risk-free rate, IV rank) | `OptionsDataProvider`, `OptionsChain`, `OptionContract`, `IVData` |
+| 4 | `ktrdr-options/ktrdr_options/positions/__init__.py` | Positions subpackage init | Exports |
+| 5 | `ktrdr-options/ktrdr_options/positions/position.py` | Position and leg dataclasses | `OptionsPosition`, `OptionsLeg`, `PositionStatus` |
+| 6 | `ktrdr-options/ktrdr_options/strategy/__init__.py` | Strategy subpackage init | Exports |
+| 7 | `ktrdr-options/ktrdr_options/strategy/decision_matrix.py` | Deterministic decision matrix (stub for M3, full impl) | `OptionsDecisionMatrix`, `StructureType`, `StructureChoice` |
+| 8 | `ktrdr-options/tests/test_black_scholes.py` | Comprehensive B-S unit tests | `TestBlackScholesEngine` |
+| 9 | `ktrdr-options/tests/test_options_data.py` | Options data provider tests | `TestOptionsDataProvider` |
+
+---
+
+## D. Files to Modify (in ktrdr repo)
+
+None. Milestone 2 does not require any changes to the ktrdr codebase.
+
+---
+
+## E. Implementation Tasks
+
+### Task 1: Implement `BlackScholesEngine.price_call()` — full Greeks
+- **File**: `ktrdr_options/backtest/black_scholes.py`
+- **Method**: `price_call(self, S, K, T, r, sigma) -> OptionPrice`
+- Implement Black-Scholes call formula:
+  - `d1 = (ln(S/K) + (r + sigma^2/2) * T) / (sigma * sqrt(T))`
+  - `d2 = d1 - sigma * sqrt(T)`
+  - `C = S * N(d1) - K * exp(-rT) * N(d2)`
+- Compute all Greeks:
+  - `delta = N(d1)`
+  - `gamma = n(d1) / (S * sigma * sqrt(T))` where `n()` is standard normal PDF
+  - `theta = -(S * n(d1) * sigma) / (2 * sqrt(T)) - r * K * exp(-rT) * N(d2)` (per calendar day: divide by 365)
+  - `vega = S * n(d1) * sqrt(T) / 100` (per 1% vol change)
+  - `rho = K * T * exp(-rT) * N(d2) / 100`
+- Return `OptionPrice(price, delta, gamma, theta, vega, rho)`
+- Handle edge cases: `T <= 0` (intrinsic value only), `sigma <= 0` (raise ValueError), `S <= 0` or `K <= 0` (raise ValueError)
+- **Test**: SPY at $523.45, K=$525, T=28/365, r=0.05, sigma=0.22 → verify price within 1% of known reference. Verify delta is between 0 and 1. Verify gamma > 0. Verify theta < 0.
+
+### Task 2: Implement `BlackScholesEngine.price_put()` — full Greeks
+- **File**: `ktrdr_options/backtest/black_scholes.py`
+- **Method**: `price_put(self, S, K, T, r, sigma) -> OptionPrice`
+- Implement Black-Scholes put formula:
+  - `P = K * exp(-rT) * N(-d2) - S * N(-d1)`
+- Greeks:
+  - `delta = N(d1) - 1` (negative for puts)
+  - `gamma = n(d1) / (S * sigma * sqrt(T))` (same as call)
+  - `theta = -(S * n(d1) * sigma) / (2 * sqrt(T)) + r * K * exp(-rT) * N(-d2)` (per calendar day)
+  - `vega = S * n(d1) * sqrt(T) / 100` (same as call)
+  - `rho = -K * T * exp(-rT) * N(-d2) / 100`
+- **Test**: Verify delta is between -1 and 0. Verify theta < 0. Verify put-call parity: `C - P = S - K * exp(-rT)` within tolerance 1e-6.
+
+### Task 3: Implement `BlackScholesEngine.price_option()` — dispatch
+- **File**: `ktrdr_options/backtest/black_scholes.py`
+- **Method**: `price_option(self, S, K, T, r, sigma, option_type: str) -> OptionPrice`
+- Dispatch to `price_call()` if `option_type == "CALL"`, `price_put()` if `option_type == "PUT"`
+- Raise `ValueError` for unknown `option_type`
+- **Test**: Verify dispatch works correctly for both types. Verify unknown type raises ValueError.
+
+### Task 4: Implement `BlackScholesEngine.find_strike_by_delta()` — Newton's method
+- **File**: `ktrdr_options/backtest/black_scholes.py`
+- **Method**: `find_strike_by_delta(self, S, T, r, sigma, target_delta, option_type, strike_step=1.0) -> float`
+- Newton's method to find K such that `delta(S, K, T, r, sigma) == target_delta`
+  - Initial guess: `K = S` (ATM)
+  - Iteration: `K_new = K - (delta(K) - target_delta) / gamma(K)` (using gamma as derivative of delta w.r.t. K, with appropriate sign)
+  - Convergence: `|delta(K) - target_delta| < 1e-4`
+  - Max iterations: 50
+  - If no convergence: raise `ValueError("Newton's method did not converge")`
+- Round result to nearest `strike_step` (e.g., 1.0 for SPY → $515, $516, etc.)
+- **Test**: 
+  - For call with target_delta=0.30: verify result delta is within 0.02 of target after rounding
+  - For put with target_delta=-0.30: same verification
+  - With strike_step=5.0: verify result is multiple of 5
+  - Verify convergence in < 50 iterations for typical inputs
+
+### Task 5: Implement `BlackScholesEngine.price_spread()` — multi-leg pricing
+- **File**: `ktrdr_options/backtest/black_scholes.py`
+- **Method**: `price_spread(self, S, legs: list[OptionsLeg], T, r, sigma) -> dict`
+- For each leg in the spread:
+  - Price the option via `price_option()`
+  - Multiply by `leg.contracts * 100` (options multiplier)
+  - If `leg.action == "SELL"`: negate price and delta (credit)
+  - If `leg.action == "BUY"`: keep as-is (debit)
+- Aggregate:
+  - `net_price`: sum of all leg prices (positive = net credit, negative = net debit)
+  - `max_profit` and `max_loss`: computed from structure (for verticals: width - credit for max_loss, credit for max_profit)
+  - `breakeven`: computed from structure type
+  - `net_delta`, `net_gamma`, `net_theta`, `net_vega`: sum across legs
+- Return dict with all fields per ARCHITECTURE.md Section 2.G
+- **Test**: Bull put spread (sell 515 put, buy 510 put): verify net_price > 0 (credit), verify net_delta > 0 (bullish), verify max_loss = (515-510)*100 - credit per contract
+
+### Task 6: Implement `BlackScholesEngine.apply_haircut()` — bid/ask simulation
+- **File**: `ktrdr_options/backtest/black_scholes.py`
+- **Method**: `apply_haircut(self, price: float, side: str) -> float`
+- `side == "credit"`: `price * (1 - self._haircut)` — you receive less
+- `side == "debit"`: `price * (1 + self._haircut)` — you pay more
+- Default `self._haircut = 0.10` (10%)
+- **Test**: Credit of $1.85 with 10% haircut → $1.665. Debit of $1.85 → $2.035. Verify.
+
+### Task 7: Implement `BlackScholesEngine.estimate_iv_from_vix()` — static method
+- **File**: `ktrdr_options/backtest/black_scholes.py`
+- **Method**: `estimate_iv_from_vix(vix: float, beta: float = 1.0) -> float`
+- Formula: `sigma = vix / 100 * max(0.8, min(2.0, beta * 0.9 + 0.3))`
+- For SPY (beta=1.0): `sigma = vix / 100 * 1.2` → but spec says `beta=1.0` default with `IV_scalar = 1.0` for SPY. Reconcile: for SPY, use `sigma = vix / 100` directly (beta=1.0, scalar=1.0).
+- **Test**: VIX=22.4, beta=1.0 → sigma=0.224. VIX=30.0, beta=1.5 → sigma = 30/100 * max(0.8, min(2.0, 1.5*0.9+0.3)) = 0.3 * 1.65 = 0.495.
+
+### Task 8: Implement `OptionsDataProvider.get_vix_history()` — download and cache
+- **File**: `ktrdr_options/data/options_data.py`
+- **Method**: `get_vix_history(self, start: str, end: str) -> pd.Series`
+- Download VIX daily close from yfinance: `yfinance.download("^VIX", start=start, end=end)["Close"]`
+- Cache to `cache/vix_daily.csv` after download
+- On subsequent calls: load from cache if cache exists and covers requested date range, else re-download
+- Return `pd.Series` with `DatetimeIndex`
+- **Test**: Verify returned Series has DatetimeIndex, no NaN values (forward-fill gaps), values > 0.
+
+### Task 9: Implement `OptionsDataProvider.get_risk_free_rate()` — FRED T-bill
+- **File**: `ktrdr_options/data/options_data.py`
+- **Method**: `get_risk_free_rate(self, as_of: str | None = None) -> float`
+- Fetch 3-month T-bill rate from FRED via `pandas_datareader.data.DataReader("DGS3MO", "fred")`
+- Cache to `cache/risk_free_rate.json` with timestamp
+- Refresh if cache > 1 day old
+- Fallback: if FRED is unreachable, return config override value or default 0.05
+- Return annualized rate as decimal (e.g., 0.0525 for 5.25%)
+- **Test**: Verify returned value is in reasonable range [0.0, 0.10]. Verify fallback works when mock raises error.
+
+### Task 10: Implement `OptionsDataProvider.compute_iv_rank()` and `compute_realized_vol()`
+- **File**: `ktrdr_options/data/options_data.py`
+- **Method**: `compute_iv_rank(self, iv_current: float, iv_history_252d: pd.Series) -> float`
+  - `rank = (iv_current - min) / (max - min) * 100`
+  - Return 50.0 if `max == min` (no range)
+- **Method**: `compute_realized_vol(self, prices: pd.Series, window: int = 20) -> float`
+  - `log_returns = np.log(prices / prices.shift(1))`
+  - `rv = log_returns.rolling(window).std() * np.sqrt(252)`
+  - Return last valid value as float
+- **Test**: 
+  - IV rank: iv_current=20, history=[10, 15, 20, 25, 30] → rank = (20-10)/(30-10)*100 = 50.0
+  - IV rank: identical values → 50.0
+  - RV: constant prices → RV ~ 0.0
+  - RV: prices with known volatility → verify within 10% of expected
+
+### Task 11: Implement dataclasses — `OptionsLeg`, `OptionsPosition`, `OptionPrice`, `OptionContract`, `OptionsChain`, `IVData`
+- **Files**: `ktrdr_options/positions/position.py`, `ktrdr_options/data/options_data.py`, `ktrdr_options/backtest/black_scholes.py`
+- Implement all dataclasses as specified in ARCHITECTURE.md Sections 2.C, 2.H, 2.G
+- Include `to_dict()` methods where specified
+- **Test**: Instantiate each dataclass with valid data, verify all fields accessible. Verify `to_dict()` returns JSON-serializable dict.
+
+### Task 12: Implement `StructureType` enum and `OptionsDecisionMatrix` stub
+- **File**: `ktrdr_options/strategy/decision_matrix.py`
+- Implement `StructureType` enum with all 9 values from ARCHITECTURE.md Section 2.E
+- Implement `StructureChoice` dataclass
+- Implement `OptionsDecisionMatrix.__init__()` with confidence thresholds
+- Implement `OptionsDecisionMatrix.suggest()` — quick lookup without confidence gates (used by SignalAggregator)
+- Stub `OptionsDecisionMatrix.select()` — full implementation in M3 Task 1
+- **Test**: `suggest("BUY", "SELL_VOL")` → `("bull_put_spread", "...")`. All 9 combinations mapped correctly.
+
+### Task 13: Validate B-S prices against known references
+- **File**: `ktrdr-options/tests/test_black_scholes.py`
+- Create comprehensive test suite:
+  - **Put-call parity**: For multiple (S, K, T, r, sigma) combinations: verify `C - P = S - K*exp(-rT)` within 1e-6
+  - **Known prices**: Compare against at least 3 textbook/CBOE reference prices within 1% tolerance
+  - **Greeks signs**: Verify call delta ∈ (0,1), put delta ∈ (-1,0), gamma > 0 always, theta < 0 always, vega > 0 always
+  - **Greeks limits**: As T → 0 for ATM options, gamma should increase. Deep ITM call delta → 1.0.
+  - **Edge cases**: Very deep OTM (delta near 0), very deep ITM (delta near ±1), very short T (near expiry), very long T
+  - **Haircut**: Verify credit haircut reduces price, debit haircut increases price
+  - **Spread pricing**: Bull put spread net credit is positive, max_loss = width - credit
+- **Test**: All above assertions pass.
+
+---
+
+## F. Acceptance Criteria
+
+### Unit Tests
+- [ ] `price_call()` matches textbook reference values within 1%
+- [ ] `price_put()` matches textbook reference values within 1%
+- [ ] Put-call parity holds: `|C - P - (S - K*exp(-rT))| < 1e-6` for 10+ test cases
+- [ ] Greeks signs correct: call delta > 0, put delta < 0, gamma > 0, theta < 0, vega > 0
+- [ ] `find_strike_by_delta()` converges within 50 iterations for all standard inputs
+- [ ] `find_strike_by_delta()` result delta is within 0.02 of target (after strike rounding)
+- [ ] `price_spread()` returns correct net price for bull put spread, iron condor, bull call spread
+- [ ] `apply_haircut()` correctly reduces credit, increases debit
+- [ ] `estimate_iv_from_vix()` returns expected values for known inputs
+- [ ] `get_vix_history()` returns non-empty Series with valid dates
+- [ ] `compute_iv_rank()` returns values in [0, 100]
+- [ ] `compute_realized_vol()` returns non-negative values
+- [ ] All dataclasses instantiate correctly and `to_dict()` returns valid dicts
+
+### Integration Tests
+- [ ] `OptionsDataProvider` downloads VIX history, computes IV rank and RV for a given date range
+- [ ] `BlackScholesEngine` can price a full bull put spread from underlying price + VIX → strikes + entry price
+- [ ] `StructureType` enum covers all 9 structure types from decision matrix
+
+### Performance Requirements
+- [ ] `price_call()` / `price_put()`: < 1ms per call (pure numpy/scipy)
+- [ ] `find_strike_by_delta()`: < 10ms per call
+- [ ] `price_spread()` for 4-leg iron condor: < 5ms
+
+---
+
+## G. Estimated Effort
+
+**7 developer-days**
+
+| Task | Days |
+|------|------|
+| B-S call + put pricing (Tasks 1-3) | 1.5 |
+| find_strike_by_delta — Newton's method (Task 4) | 1.0 |
+| price_spread + haircut (Tasks 5-6) | 1.0 |
+| IV estimation (Task 7) | 0.5 |
+| VIX history + risk-free rate (Tasks 8-9) | 1.0 |
+| IV rank + RV computation (Task 10) | 0.5 |
+| Dataclasses + decision matrix stub (Tasks 11-12) | 0.5 |
+| B-S validation test suite (Task 13) | 1.0 |
+
+The B-S implementation (Tasks 1-4) is pure math — low uncertainty. The data infrastructure (Tasks 8-9) depends on external API reliability (yfinance, FRED) but has clear fallback strategies.
+
+---
+
+## H. Open Questions / Risks
+
+1. **`[VALIDATE EMPIRICALLY]`** The 10% bid/ask haircut is a conservative guess. If OptionsDX data is acquired later (`[DECISION NEEDED]` — budget), calibrate the haircut against real bid/ask spreads for SPY options.
+
+2. **FRED API access**: `pandas_datareader` FRED access is free but can be rate-limited. The fallback to a config-override risk-free rate (`backtest.risk_free_rate_override` in YAML) handles this. For backtesting, a static rate is acceptable since risk-free rate changes slowly.
+
+3. **VIX data gaps**: yfinance VIX history may have gaps on holidays/weekends. Forward-fill (or use last valid value) is the standard approach. Document this behavior.
+
+4. **Known B-S limitations**: The implementation deliberately ignores vol smile, dividends, early exercise, and term structure. These are documented in DESIGN.md Section 5 and are acceptable for synthetic backtest. The haircut compensates partially for these approximations.
+
+5. **Spread max profit/loss computation**: For simple vertical spreads, max profit and max loss are straightforward. For iron condors, the computation is slightly more complex (max loss on each side). Ensure `price_spread()` handles all in-scope structures: bull put, bear call, bull call, bear put, iron condor, long call, long put, long straddle.
+
+6. **`scipy` dependency**: `scipy.stats.norm.cdf` and `norm.pdf` are the only scipy functions needed. If scipy is not available, `math.erf` can substitute for `norm.cdf`. However, scipy is a standard dependency and should be included.

--- a/docs/designs/autonomous-options-trading/milestones/MILESTONE_3.md
+++ b/docs/designs/autonomous-options-trading/milestones/MILESTONE_3.md
@@ -1,0 +1,345 @@
+# Milestone 3: Full Synthetic Backtest Loop
+
+---
+
+## A. Objective
+
+Run an end-to-end synthetic backtest on 2-year SPY data (2022-01-01 to 2024-01-01) combining ktrdr directional signals, Kronos vol regime classification, Black-Scholes options pricing, the decision matrix, and full position management. This milestone proves the combined system generates positive risk-adjusted returns in simulation. Target: Sharpe > 0.50 on at least 50 trades with max drawdown < 25%.
+
+---
+
+## B. Go/No-Go Gate (from previous milestone)
+
+**Entry gate from M2**:
+- [ ] `BlackScholesEngine` passes all validation tests: put-call parity holds within 1e-6, prices match textbook references within 1%
+- [ ] Greeks signs verified: call delta > 0, put delta < 0, gamma > 0, theta < 0, vega > 0
+- [ ] `OptionsDataProvider` successfully downloads and caches VIX history
+- [ ] `compute_iv_rank()` and `compute_realized_vol()` produce valid results
+- [ ] All dataclasses (`OptionsLeg`, `OptionsPosition`, `OptionPrice`, etc.) implemented and tested
+- [ ] `StructureType` enum and `OptionsDecisionMatrix.suggest()` cover all 9 matrix cells
+
+**Additional prerequisites**:
+- [ ] ktrdr installed as a Python package or on PYTHONPATH (library imports required)
+- [ ] Trained ktrdr model available for SPY (e.g., `trend_tb_lstm_signal_v1`)
+- [ ] Kronos classifier trained from M1 (or IV rank heuristic fallback ready)
+- [ ] Pre-computed Kronos embeddings from M1
+
+---
+
+## C. Files to Create (proposed paths)
+
+| # | File Path | Purpose | Key Classes/Functions |
+|---|-----------|---------|----------------------|
+| 1 | `ktrdr-options/ktrdr_options/backtest/engine.py` | Options backtest engine — main bar-by-bar loop | `OptionsBacktestEngine`, `OptionsBacktestConfig`, `OptionsBacktestTrade`, `OptionsBacktestResults` |
+| 2 | `ktrdr-options/ktrdr_options/positions/manager.py` | Position lifecycle management + SQLite persistence | `OptionsPositionManager` |
+| 3 | `ktrdr-options/ktrdr_options/persistence/__init__.py` | Persistence subpackage init | Exports |
+| 4 | `ktrdr-options/ktrdr_options/persistence/schema.py` | SQLite schema creation for backtest tables | `create_backtest_schema()`, `create_live_schema()` |
+| 5 | `ktrdr-options/ktrdr_options/signals/aggregator.py` | Signal aggregation (combines ktrdr + Kronos + IV) | `SignalAggregator`, `DecisionInput` |
+| 6 | `ktrdr-options/ktrdr_options/backtest_cli.py` | CLI: run synthetic backtest | `main()` |
+| 7 | `ktrdr-options/tests/test_decision_matrix.py` | Decision matrix unit tests | `TestOptionsDecisionMatrix` |
+| 8 | `ktrdr-options/tests/test_position_manager.py` | Position manager unit tests | `TestOptionsPositionManager` |
+| 9 | `ktrdr-options/tests/test_backtest_engine.py` | Backtest engine integration tests | `TestOptionsBacktestEngine` |
+
+---
+
+## D. Files to Modify (in ktrdr repo)
+
+| # | File Path | Change | Why |
+|---|-----------|--------|-----|
+| — | None required for M3 | The backtest engine imports ktrdr as a library. No code changes needed in ktrdr for backtest mode. The `nn_probabilities` are already available via `TradingDecision.reasoning["nn_probabilities"]` when using library imports. | ktrdr API extension (adding `probabilities` to REST response) is deferred to M4. |
+
+**Setup requirement**: ktrdr must be installed as a Python package (`pip install -e /path/to/ktrdr`) or on `PYTHONPATH`. Document this in the backtest CLI help text.
+
+---
+
+## E. Implementation Tasks
+
+### Task 1: Implement `OptionsDecisionMatrix.select()` — full 8-cell grid with confidence gates
+- **File**: `ktrdr_options/strategy/decision_matrix.py`
+- **Method**: `select(self, decision_input: DecisionInput) -> StructureChoice`
+- Implement the decision matrix per ARCHITECTURE.md Section 2.E and DESIGN.md Section 4:
+
+  | ktrdr \ Kronos | SELL_VOL | NEUTRAL | BUY_VOL |
+  |---------------|----------|---------|---------|
+  | BUY | bull_put_spread | bull_call_spread | long_call |
+  | HOLD | iron_condor | NO_TRADE | long_straddle |
+  | SELL | bear_call_spread | bear_put_spread | long_put |
+
+- Apply confidence gates:
+  1. `ktrdr_confidence < min_ktrdr_confidence (0.45)` → NO_TRADE
+  2. For long_call/long_put: `ktrdr_confidence < min_ktrdr_confidence_naked (0.65)` → NO_TRADE
+  3. For iron_condor/long_straddle: `kronos_confidence < min_kronos_confidence_vol (0.70)` → NO_TRADE
+  4. For all others: `kronos_confidence < min_kronos_confidence_other (0.50)` → NO_TRADE
+- Populate `StructureChoice` with target DTE range, delta, width from config
+- Set `confidence_gate_passed = True/False` accordingly
+- **Test**: All 9 (signal, regime) combinations map to expected structure. Confidence gates correctly reject trades below thresholds. Edge case: HOLD+NEUTRAL → NO_TRADE always.
+
+### Task 2: Implement `OptionsPositionManager.open_position()`
+- **File**: `ktrdr_options/positions/manager.py`
+- **Method**: `open_position(self, recommendation: TradeRecommendation, decision_input: DecisionInput) -> OptionsPosition`
+- Validate risk limits:
+  - `recommendation.max_risk <= decision_input.max_risk_per_trade`
+  - Total open risk + new risk <= total risk budget
+- Assign UUID to position and each leg
+- Create `OptionsPosition` with all entry metrics from recommendation
+- Persist to SQLite `positions` table (or `backtest_trades` in backtest mode)
+- Add to `self._open_positions` in-memory cache
+- **Test**: Open position, verify it appears in `get_open_positions()`. Verify risk validation rejects position exceeding budget. Verify UUID is unique.
+
+### Task 3: Implement `OptionsPositionManager.mark_to_market()`
+- **File**: `ktrdr_options/positions/manager.py`
+- **Method**: `mark_to_market(self, position, underlying_price, current_iv, risk_free_rate, current_date) -> OptionsPosition`
+- For each leg in position:
+  - Compute remaining DTE from `leg.expiry` and `current_date`
+  - Re-price via `BlackScholesEngine.price_option()` with current S, T, r, sigma
+  - Update `leg.current_price`, `leg.current_delta/gamma/theta/vega`
+- Compute position-level:
+  - `current_pnl`: sum of (current_price - entry_price) * contracts * 100 * direction
+  - `current_pnl_pct`: pnl / abs(max_loss) * 100
+  - `dte_remaining`: min DTE across all legs
+  - `net_delta/gamma/theta/vega`: sum across legs (accounting for direction)
+- Update SQLite record
+- **Test**: Open bull put spread at known prices, mark-to-market with underlying 2% higher → verify positive PnL. Verify Greeks update correctly.
+
+### Task 4: Implement `OptionsPositionManager.check_exit_conditions()`
+- **File**: `ktrdr_options/positions/manager.py`
+- **Method**: `check_exit_conditions(self, position, current_ktrdr_signal) -> tuple[bool, str]`
+- Check conditions in priority order:
+  1. `dte_remaining < position.time_exit_dte (7)` → `(True, "time_exit")`
+  2. `current_pnl >= position.max_profit * (position.take_profit_pct / 100)` → `(True, "take_profit")`
+  3. `current_pnl <= -abs(position.max_loss) * (position.stop_loss_pct / 100)` → `(True, "stop_loss")`
+  4. Signal reversal: ktrdr signal flipped (BUY→SELL or SELL→BUY) AND `signal_reversal_exit == True` → `(True, "signal_reversal")`
+  - HOLD does not trigger signal reversal (only actual direction flip)
+- Return `(False, "")` if no exit condition met
+- **Test**: Position with dte=5 → exits with "time_exit". Position at 60% of max profit with take_profit_pct=50 → exits with "take_profit". Position at max loss → exits with "stop_loss". Signal flip BUY→SELL → exits. Signal BUY→HOLD → does NOT exit.
+
+### Task 5: Implement `OptionsPositionManager.close_position()`
+- **File**: `ktrdr_options/positions/manager.py`
+- **Method**: `close_position(self, position, exit_reason, exit_timestamp) -> OptionsPosition`
+- Apply bid/ask haircut to exit prices:
+  - For credit spreads being closed: haircut the debit-to-close
+  - For debit spreads being closed: haircut the credit-to-close
+- Compute final `exit_pnl` with haircut applied
+- Update position: `status = CLOSED`, `exit_timestamp`, `exit_reason`, `exit_pnl`
+- Write to SQLite `trades` table (or `backtest_trades` in backtest mode)
+- Remove from `self._open_positions`
+- **Test**: Close position, verify it no longer appears in `get_open_positions()`. Verify `exit_pnl` includes haircut (less favorable than theoretical).
+
+### Task 6: Implement `OptionsPositionManager.get_portfolio_greeks()`
+- **File**: `ktrdr_options/positions/manager.py`
+- **Method**: `get_portfolio_greeks(self) -> dict[str, float]`
+- Sum across all open positions: `total_delta`, `total_gamma`, `total_theta`, `total_vega`
+- Compute `total_risk`: sum of `abs(max_loss)` across open positions
+- Return dict with all fields + `position_count`
+- **Test**: Two open positions, verify aggregates match manual sum.
+
+### Task 7: Implement `SignalAggregator.aggregate()`
+- **File**: `ktrdr_options/signals/aggregator.py`
+- **Method**: `aggregate(self, ktrdr_signal, kronos_regime, iv_data, current_price, ...) -> DecisionInput`
+- Combine all inputs into `DecisionInput` dataclass:
+  - Compute `price_change_1d` and `price_change_5d` from `price_history_5d`
+  - Compute `position_size_multiplier` from ktrdr probability distribution:
+    - `probability_spread = max_prob - second_highest_prob`
+    - `< 0.10` → 0.5x, `< 0.25` → 0.75x, else 1.0x
+  - `max_risk_per_trade = account_value * max_risk_pct * multiplier`
+  - Pre-populate `matrix_suggestion` via `OptionsDecisionMatrix.suggest()`
+- **Test**: Aggregate with known inputs, verify `max_risk_per_trade` computed correctly. Verify `matrix_suggestion` populated. Verify position size multiplier: uniform-ish probabilities → 0.5x, skewed → 1.0x.
+
+### Task 8: Implement SQLite schema for backtest tables
+- **File**: `ktrdr_options/persistence/schema.py`
+- **Function**: `create_backtest_schema(db_path: str) -> sqlite3.Connection`
+  - Create `backtest_runs` table per ARCHITECTURE.md Section 4
+  - Create `backtest_trades` table per ARCHITECTURE.md Section 4
+  - Create indexes
+- **Function**: `create_live_schema(db_path: str) -> sqlite3.Connection` (stub for M4)
+  - Create `positions`, `trades`, `signals`, `calibration` tables
+- **Test**: Create schema, verify all tables exist with correct columns. Insert + query test row.
+
+### Task 9: Implement `OptionsBacktestEngine._load_ktrdr_pipeline()`
+- **File**: `ktrdr_options/backtest/engine.py`
+- **Method**: `_load_ktrdr_pipeline(self) -> None`
+- Import and initialize ktrdr components:
+  ```python
+  from ktrdr.backtesting.decision_function import DecisionFunction
+  from ktrdr.backtesting.model_bundle import ModelBundle
+  from ktrdr.indicators.indicator_engine import IndicatorEngine
+  from ktrdr.fuzzy.engine import FuzzyEngine
+  ```
+- Load model via `ModelBundle.load(config.model_path)`
+- Initialize `DecisionFunction` with loaded model
+- Load OHLCV data via ktrdr's `LocalDataLoader`
+- **Test**: Verify import succeeds (requires ktrdr on PYTHONPATH). Verify model loads without error. Verify OHLCV data has expected date range.
+
+### Task 10: Implement `OptionsBacktestEngine._load_kronos()` and `_load_vix_data()`
+- **File**: `ktrdr_options/backtest/engine.py`
+- **Method**: `_load_kronos(self) -> None`
+  - If `config.kronos_embeddings_path` set: load pre-computed embeddings from `.pt`
+  - If `config.kronos_classifier_path` set: load classifier weights
+  - Else: initialize `KronosVolClassifier` and compute embeddings (slow)
+- **Method**: `_load_vix_data(self) -> None`
+  - If `config.vix_data_path` set: load from CSV
+  - Else: download via `OptionsDataProvider.get_vix_history()`
+  - Store in `self._vix_history`
+- **Test**: Load with pre-computed embeddings, verify shape matches expected. Load VIX, verify covers backtest date range.
+
+### Task 11: Implement `OptionsBacktestEngine.run()` — main bar-by-bar loop
+- **File**: `ktrdr_options/backtest/engine.py`
+- **Method**: `run(self) -> OptionsBacktestResults`
+- Main loop per ARCHITECTURE.md Section 2.J:
+  ```
+  for each bar t in [start_date, end_date]:
+      1. ktrdr_decision = self._compute_ktrdr_signal(features_t, ...) → TradingDecision
+         Extract: signal, nn_probabilities from decision.reasoning
+      2. kronos_regime = self._compute_kronos_regime(bar_index, iv_rank, timestamp)
+      3. iv_rank, current_iv, rv_20d = self._compute_iv_context(timestamp, price)
+      4. decision_input = aggregator.aggregate(...)
+      5. structure_choice = decision_matrix.select(decision_input)
+      6. If structure != NO_TRADE and confidence gates pass:
+         a. strikes = bs_engine.find_strike_by_delta(...)
+         b. entry = bs_engine.price_spread(...) + apply_haircut(...)
+         c. recommendation = build TradeRecommendation from structure_choice + B-S results
+         d. position_manager.open_position(recommendation, decision_input)
+      7. For each open position:
+         a. position_manager.mark_to_market(position, S_t, sigma_t, r, date)
+         b. should_exit, reason = position_manager.check_exit_conditions(position, signal)
+         c. If exit: position_manager.close_position(position, reason, timestamp)
+      8. Record equity curve point: {date, equity, drawdown}
+  ```
+- After loop: compute all metrics, write `backtest_runs` row to SQLite
+- **Test**: Run on small date range (3 months), verify: at least some trades opened and closed, equity curve has correct length, SQLite has records.
+
+### Task 12: Implement `OptionsBacktestEngine._compute_ktrdr_signal()`
+- **File**: `ktrdr_options/backtest/engine.py`
+- **Method**: `_compute_ktrdr_signal(self, features, position_status, bar, last_signal_time) -> TradingDecision`
+- Call ktrdr's `DecisionFunction.__call__()` with same interface as ktrdr's existing BacktestingEngine
+- Extract `nn_probabilities` from `decision.reasoning["nn_probabilities"]`
+- **Test**: Verify returns valid `TradingDecision` with signal in {"BUY", "SELL", "HOLD"} and nn_probabilities dict with 3 keys summing to ~1.0.
+
+### Task 13: Implement `OptionsBacktestEngine._compute_metrics()`
+- **File**: `ktrdr_options/backtest/engine.py`
+- **Method**: `_compute_metrics(self, trades, equity_curve) -> dict`
+- Compute from trade list:
+  - `total_return` and `total_return_pct`
+  - `sharpe_ratio`: annualized Sharpe from equity curve daily returns, `mean(returns) / std(returns) * sqrt(252)`
+  - `max_drawdown_pct`: max peak-to-trough decline in equity curve
+  - `win_rate`: % of trades with positive PnL
+  - `profit_factor`: sum of wins / sum of losses
+  - `avg_win_pct`, `avg_loss_pct`
+  - `avg_dte_at_entry`, `avg_holding_period_days`
+- Options-specific metrics:
+  - `avg_theta_collected`: average daily theta on open positions
+  - `avg_delta_exposure`: average net delta across all open days
+  - `gamma_risk_events`: count of days where any position had gamma > threshold near expiry
+  - `structure_breakdown`: dict of trade count per structure type
+- Signal distribution: count of BUY/SELL/HOLD signals generated
+- **Test**: Given known trade list with 3 wins ($100 each) and 2 losses ($-50 each), verify Sharpe, win_rate=0.6, profit_factor=3.0.
+
+### Task 14: Write `backtest_runs` and `backtest_trades` to SQLite
+- **File**: `ktrdr_options/backtest/engine.py`
+- After loop completes:
+  - Insert `backtest_runs` row with all metrics (per ARCHITECTURE.md Section 4)
+  - Verify all `backtest_trades` rows were written during the loop
+  - Include `execution_time_seconds`
+- **Test**: After backtest run, query SQLite and verify: run_id matches, trade count matches, metrics stored correctly.
+
+### Task 15: Write CLI entry point
+- **File**: `ktrdr_options/backtest_cli.py`
+- **Function**: `main()`
+- CLI: `python -m ktrdr_options.backtest --config ktrdr-options-config.yaml --start 2022-01-01 --end 2024-01-01 [--db-path backtest_results.db]`
+- Flow:
+  1. Load config from YAML
+  2. Build `OptionsBacktestConfig`
+  3. Create `OptionsBacktestEngine`
+  4. Run backtest
+  5. Print results table: metrics summary, top trades, structure breakdown
+  6. Print trade log: date, structure, entry, exit, PnL, exit_reason
+  7. Exit with code 0 if Sharpe > 0.50, code 1 otherwise
+- **Test**: Run CLI end-to-end on 3-month period. Verify stdout has expected sections.
+
+### Task 16: Tune and validate — sweep parameters if gate fails
+- If initial backtest does NOT meet Sharpe > 0.50:
+  - Sweep confidence thresholds: `min_ktrdr_confidence` in [0.40, 0.45, 0.50]
+  - Sweep exit parameters: `take_profit_pct` in [40, 50, 60], `stop_loss_pct` in [75, 100, 150]
+  - Sweep DTE: test 14, 21, 30, 45 day windows
+  - Analyze structure breakdown: which structures are profitable, which are not?
+  - Consider removing unprofitable structures from the matrix
+- Document findings in backtest results
+- **Test**: At least 3 parameter configurations tested. Best configuration documented with metrics.
+- `[VALIDATE EMPIRICALLY]`: This is the Sharpe > 0.50 gate.
+
+---
+
+## F. Acceptance Criteria
+
+### Unit Tests
+- [ ] `OptionsDecisionMatrix.select()` correctly maps all 9 (signal, regime) combinations
+- [ ] `OptionsDecisionMatrix.select()` returns NO_TRADE when confidence gates fail
+- [ ] `OptionsPositionManager.open_position()` creates valid position with UUID
+- [ ] `OptionsPositionManager.open_position()` rejects position exceeding risk budget
+- [ ] `OptionsPositionManager.mark_to_market()` updates PnL and Greeks correctly
+- [ ] `OptionsPositionManager.check_exit_conditions()` triggers on time_exit, take_profit, stop_loss, signal_reversal
+- [ ] `OptionsPositionManager.close_position()` applies haircut and records exit
+- [ ] `OptionsPositionManager.get_portfolio_greeks()` sums correctly across positions
+- [ ] `SignalAggregator.aggregate()` computes position size multiplier correctly
+- [ ] `SignalAggregator.compute_position_size_multiplier()` returns 0.5/0.75/1.0 for appropriate spreads
+- [ ] `_compute_metrics()` computes Sharpe, win_rate, profit_factor correctly for known inputs
+- [ ] SQLite schema creates all tables with correct columns and indexes
+
+### Integration Tests
+- [ ] Full backtest runs end-to-end on 3+ month SPY data without errors
+- [ ] ktrdr library imports work (DecisionFunction, ModelBundle, etc.)
+- [ ] Kronos embeddings load from cache and classifier produces regimes
+- [ ] SQLite contains all trades and run summary after backtest
+- [ ] Equity curve has correct number of data points (one per trading day)
+
+### Empirical Validation Gates
+- [ ] **`[VALIDATE EMPIRICALLY]`** Sharpe > 0.50 on 2022-2024 SPY data
+- [ ] **`[VALIDATE EMPIRICALLY]`** >= 50 trades produced
+- [ ] **`[VALIDATE EMPIRICALLY]`** Max drawdown < 25%
+- [ ] Win rate reported and reasonable (> 40%)
+- [ ] Profit factor > 1.0
+
+### Performance Requirements
+- [ ] Full 2-year backtest completes in < 10 minutes (excluding Kronos embedding extraction, which is pre-cached)
+- [ ] Memory usage < 4GB during backtest
+
+---
+
+## G. Estimated Effort
+
+**12 developer-days**
+
+| Task | Days |
+|------|------|
+| Decision matrix full impl (Task 1) | 1.0 |
+| Position manager — open/close/MTM (Tasks 2-5) | 2.5 |
+| Portfolio Greeks (Task 6) | 0.5 |
+| Signal aggregator (Task 7) | 1.0 |
+| SQLite schema (Task 8) | 0.5 |
+| ktrdr pipeline loading (Task 9) | 1.0 |
+| Kronos + VIX loading (Task 10) | 0.5 |
+| Main backtest loop (Task 11) | 2.0 |
+| ktrdr signal computation (Task 12) | 0.5 |
+| Metrics computation (Task 13) | 1.0 |
+| SQLite writes + CLI (Tasks 14-15) | 1.0 |
+| Tuning and validation (Task 16) | 1.0 |
+
+This is the largest milestone. The main backtest loop (Task 11) integrates all prior work and has the most complexity. The ktrdr pipeline loading (Task 9) may require debugging import issues.
+
+---
+
+## H. Open Questions / Risks
+
+1. **ktrdr as library**: The backtest engine imports ktrdr directly (not via REST). This requires ktrdr to be installed (`pip install -e .` or on PYTHONPATH). If ktrdr has complex dependencies or installation issues, this could block M3. **Mitigation**: Test `import ktrdr` early. Document exact setup steps.
+
+2. **ktrdr model availability**: The backtest needs a trained ktrdr model for SPY. If no model exists for SPY at the required timeframe, one must be trained first. `[DECISION NEEDED]`: Confirm which ktrdr model and timeframe to use for SPY backtest.
+
+3. **`[VALIDATE EMPIRICALLY]`** The Sharpe > 0.50 target on synthetic data with B-S reconstruction and 10% haircut is achievable but not guaranteed. If the signal quality is insufficient, the system may produce Sharpe < 0.50 even with parameter tuning. In that case: investigate whether the ktrdr signal itself is profitable on stock trades during the same period — if not, the options layer cannot rescue a non-predictive signal.
+
+4. **Position overlap**: Multiple positions may be open simultaneously. The backtest engine must track and mark-to-market all open positions each bar. The `max_positions: 5` config limit prevents unbounded position count.
+
+5. **Data alignment**: ktrdr signals are generated on bar timeframes (e.g., 1h), but VIX and options pricing use daily data. The backtest must align these: use end-of-day VIX and risk-free rate, but use intrabar prices for underlying. Document the alignment strategy.
+
+6. **Look-ahead bias**: The Kronos classifier was trained on the same date range as the backtest. This introduces optimistic bias. **Mitigation**: The classifier test set (Jul-Dec 2023) is separate from training, but the backtest covers the full 2022-2024 period. Ideally, train Kronos on 2020-2021 and backtest on 2022-2024 to avoid any overlap. `[DECISION NEEDED]`: Should we retrain Kronos on earlier data for cleaner backtest?
+
+7. **`[VALIDATE EMPIRICALLY]`** Exit timing: take profit at 50% of max profit is a standard heuristic for credit spreads. For debit spreads and long options, the take profit threshold should likely be different (higher, e.g., 100-200%). The decision matrix should set structure-specific exit parameters.

--- a/docs/designs/autonomous-options-trading/milestones/MILESTONE_4.md
+++ b/docs/designs/autonomous-options-trading/milestones/MILESTONE_4.md
@@ -1,0 +1,393 @@
+# Milestone 4: Live/Paper Infrastructure (No IBKR Yet)
+
+---
+
+## A. Objective
+
+Build the live analysis pipeline: ktrdr HTTP client for real-time signal fetching, Opus 4.7 strategy advisor with structured prompting and fallback logic, and the LuxOrchestrator that ties everything together in a scheduled analysis cycle. This milestone validates that the full analysis loop (fetch signals → aggregate → advise → log → notify) runs cleanly end-to-end in under 90 seconds, with proper SQLite persistence and Telegram notifications. No trade execution occurs — this is analysis-only mode.
+
+---
+
+## B. Go/No-Go Gate (from previous milestone)
+
+**Entry gate from M3**:
+- [ ] Synthetic backtest Sharpe > 0.50 on 2022-2024 SPY data
+- [ ] >= 50 trades produced in backtest
+- [ ] Max drawdown < 25%
+- [ ] All backtest trades and metrics persisted to SQLite
+- [ ] `OptionsDecisionMatrix`, `OptionsPositionManager`, `SignalAggregator` fully tested and working
+- [ ] `BlackScholesEngine` validated and tested
+
+**Additional prerequisites**:
+- [ ] ktrdr REST API server can be started and responds to health check
+- [ ] Anthropic API key available (env var: `ANTHROPIC_API_KEY`)
+- [ ] Telegram bot token and chat ID configured (env vars: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`)
+
+---
+
+## C. Files to Create (proposed paths)
+
+| # | File Path | Purpose | Key Classes/Functions |
+|---|-----------|---------|----------------------|
+| 1 | `ktrdr-options/ktrdr_options/signals/ktrdr_client.py` | Async HTTP client for ktrdr REST API | `KtrdrSignalClient`, `KtrdrSignal`, `KtrdrAPIError`, `KtrdrStaleDataError` |
+| 2 | `ktrdr-options/ktrdr_options/strategy/opus_advisor.py` | Opus 4.7 strategy advisor with fallback | `OpusStrategyAdvisor`, `TradeRecommendation`, `OptionsLeg`, `ExitPlan` |
+| 3 | `ktrdr-options/ktrdr_options/orchestrator.py` | Main analysis/trading loop | `LuxOrchestrator`, `CycleResult` |
+| 4 | `ktrdr-options/ktrdr_options/strategy/opus_prompt.py` | Opus 4.7 prompt template and JSON schema | `build_opus_prompt()`, `OPUS_SYSTEM_PROMPT`, `TRADE_RECOMMENDATION_SCHEMA` |
+| 5 | `ktrdr-options/tests/test_ktrdr_client.py` | ktrdr client tests with mock HTTP | `TestKtrdrSignalClient` |
+| 6 | `ktrdr-options/tests/test_opus_advisor.py` | Opus advisor tests with mock API | `TestOpusStrategyAdvisor` |
+| 7 | `ktrdr-options/tests/test_orchestrator.py` | Orchestrator integration tests | `TestLuxOrchestrator` |
+
+---
+
+## D. Files to Modify (in ktrdr repo)
+
+| # | File Path | Change | Why |
+|---|-----------|--------|-----|
+| 1 | `ktrdr/api/endpoints/models.py` | Add `probabilities: dict[str, float] | None = None` to `Prediction` model. In prediction handler, extract `nn_probabilities` from `reasoning` dict and populate field. | Enables KtrdrSignalClient to receive full probability distribution needed for position sizing and Opus context. |
+
+**Exact change (~10 lines)**:
+
+```python
+# In Prediction model (approx line 200):
+class Prediction(BaseModel):
+    signal: str
+    confidence: float
+    signal_strength: float
+    probabilities: dict[str, float] | None = None  # ADD THIS LINE
+
+# In prediction endpoint handler (approx line 225), after obtaining TradingDecision:
+# ADD: Extract nn_probabilities from reasoning dict
+nn_probs = trading_decision.reasoning.get("nn_probabilities") if trading_decision.reasoning else None
+# MODIFY: Pass to Prediction constructor
+prediction = Prediction(
+    signal=trading_decision.signal.value,
+    confidence=trading_decision.confidence,
+    signal_strength=trading_decision.signal_strength,
+    probabilities=nn_probs,  # ADD THIS LINE
+)
+```
+
+**Backward compatibility**: Field is optional with `None` default. Existing clients unaffected.
+
+---
+
+## E. Implementation Tasks
+
+### Task 1: Extend ktrdr API — add `probabilities` to `PredictionResponse`
+- **File**: `ktrdr/api/endpoints/models.py` (in ktrdr repo)
+- Add `probabilities: dict[str, float] | None = None` to `Prediction` Pydantic model
+- In prediction endpoint handler: extract `reasoning.get("nn_probabilities")` from `TradingDecision` and pass to `Prediction`
+- **Test**: Start ktrdr server, call `POST /api/v1/models/predict`. Verify response JSON includes `prediction.probabilities` with keys "BUY", "HOLD", "SELL" summing to ~1.0.
+
+### Task 2: Implement `KtrdrSignalClient.predict()` — async HTTP with retries
+- **File**: `ktrdr_options/signals/ktrdr_client.py`
+- **Method**: `predict(self, model_name, symbol, timeframe, test_date) -> KtrdrSignal`
+- Use `httpx.AsyncClient` for async HTTP
+- Retry logic: 3 retries with exponential backoff (2s, 4s, 8s)
+- Stale data detection: if `response.test_date` is > 2 bars behind current time, raise `KtrdrStaleDataError`
+- Map response to `KtrdrSignal` dataclass:
+  - `signal`, `confidence`, `signal_strength` from `prediction`
+  - `probabilities` from `prediction.probabilities` (handle None: construct from signal+confidence as fallback)
+  - `input_features` from response
+- Raise `KtrdrAPIError` after retries exhausted
+- **Test**: Mock httpx to return valid response → verify KtrdrSignal fields. Mock httpx to return 500 3 times → verify KtrdrAPIError raised. Mock httpx to return stale test_date → verify KtrdrStaleDataError.
+
+### Task 3: Implement `KtrdrSignalClient.health_check()` — simple GET /health
+- **File**: `ktrdr_options/signals/ktrdr_client.py`
+- **Method**: `health_check(self) -> bool`
+- `GET {base_url}/health` or `GET {base_url}/api/v1/health`
+- Return True if status 200, False otherwise
+- No retries (quick check)
+- **Test**: Mock healthy server → True. Mock unreachable → False.
+
+### Task 4: Implement `OptionsDataProvider.get_options_chain()` — yfinance for paper mode
+- **File**: `ktrdr_options/data/options_data.py`
+- **Method**: `get_options_chain(self, symbol, min_dte, max_dte, min_delta, max_delta) -> OptionsChain`
+- For `mode == "paper"` or `mode == "backtest"`:
+  - Use `yfinance.Ticker(symbol).option_chain(expiry)` for each available expiry
+  - Filter by DTE range and delta range
+  - Map to `OptionContract` dataclass list
+  - Compute Greeks via `BlackScholesEngine` if not provided by yfinance
+- For `mode == "live"`: stub (implemented in M5 via IBKR MCP)
+- Return `OptionsChain` with filtered contracts
+- **Test**: Mock yfinance response → verify filtering logic. Verify contracts sorted by strike.
+
+### Task 5: Implement `OptionsDataProvider.get_iv_data()` — combined IV context
+- **File**: `ktrdr_options/data/options_data.py`
+- **Method**: `get_iv_data(self, symbol, as_of) -> IVData`
+- Fetch VIX history (from cache or yfinance)
+- Compute IV rank from trailing 252-day VIX
+- Compute current IV: `vix / 100` for SPY, `vix / 100 * beta_scalar` for single names
+- Compute 20-day realized vol from underlying prices
+- Return `IVData(current_iv, iv_rank, iv_percentile, iv_history, vix, rv_20d)`
+- **Test**: Verify all fields populated. Verify iv_rank in [0, 100]. Verify rv_20d > 0.
+
+### Task 6: Implement `OpusStrategyAdvisor.advise()` — full Opus 4.7 integration
+- **File**: `ktrdr_options/strategy/opus_advisor.py`
+- **Method**: `advise(self, decision_input: DecisionInput) -> TradeRecommendation`
+- Flow:
+  1. Build prompt via `self._build_prompt(decision_input)`
+  2. Call Anthropic API: `self._client.messages.create(model=self._model, ...)` with extended thinking enabled
+  3. Parse JSON from response text → `TradeRecommendation`
+  4. Validate via `self._validate_recommendation(recommendation, decision_input)`
+  5. If validation fails: retry up to `self._max_retries` times with explicit error feedback in prompt
+  6. If still fails: fall back to `self._fallback_to_matrix(decision_input, reason)`
+- Set `recommendation.source = "opus"` or `"matrix"` accordingly
+- **Test**: Mock Anthropic API to return valid JSON → verify TradeRecommendation parsed correctly. Mock API to return invalid JSON → verify retry then matrix fallback. Mock API timeout → verify matrix fallback with `warnings=["opus_fallback"]`.
+
+### Task 7: Implement `OpusStrategyAdvisor._build_prompt()` — structured prompt template
+- **File**: `ktrdr_options/strategy/opus_prompt.py`
+- **Constant**: `OPUS_SYSTEM_PROMPT` — system prompt for Opus 4.7:
+  ```
+  You are an options strategy advisor for an autonomous trading system. You receive structured market data and must recommend a specific options trade.
+
+  ALLOWED STRUCTURES: bull_put_spread, iron_condor, bull_call_spread, bear_call_spread, long_call, long_straddle, bear_put_spread, long_put
+
+  CONSTRAINTS:
+  - max_risk must not exceed the provided max_risk_per_trade
+  - All strikes must come from the provided options chain (if available)
+  - Expiry must be within the provided DTE range
+  - Respond ONLY with valid JSON matching the schema below
+
+  RESPONSE SCHEMA:
+  {
+    "action": "OPEN" | "HOLD",
+    "structure": "<structure_name>",
+    "legs": [{"action": "BUY"|"SELL", "option_type": "CALL"|"PUT", "strike": float, "expiry": "YYYY-MM-DD", "contracts": int}],
+    "expected_credit": float | null,
+    "expected_debit": float | null,
+    "max_risk": float,
+    "max_profit": float,
+    "breakeven": float | [float, float],
+    "exit_plan": {"take_profit_pct": float, "stop_loss_pct": float, "time_exit_dte": int},
+    "reasoning": "string",
+    "confidence": "HIGH" | "MEDIUM" | "LOW",
+    "warnings": []
+  }
+  ```
+- **Function**: `build_opus_prompt(decision_input: DecisionInput) -> str`
+  - Render `DecisionInput.to_dict()` as formatted JSON in user message
+  - Include: current price, ktrdr signal + probabilities, Kronos regime + confidence, IV rank, VIX, RV_20d, options chain (if available), current positions, account state, decision matrix suggestion
+  - Add the matrix suggestion as context: "The deterministic decision matrix suggests: {structure}. You may agree, modify, or override."
+- **Test**: Build prompt with sample DecisionInput, verify JSON is well-formed and contains all required fields. Verify prompt length < 4000 tokens (stay within reasonable limits).
+
+### Task 8: Implement `OpusStrategyAdvisor._parse_response()` and `_validate_recommendation()`
+- **File**: `ktrdr_options/strategy/opus_advisor.py`
+- **Method**: `_parse_response(self, response_text: str) -> TradeRecommendation`
+  - Extract JSON from response (handle markdown code blocks)
+  - Map to `TradeRecommendation` dataclass
+  - Raise `ValueError` if JSON is malformed or missing required fields
+- **Method**: `_validate_recommendation(self, recommendation, decision_input) -> list[str]`
+  - Check: `structure in ALLOWED_STRUCTURES`
+  - Check: `max_risk <= decision_input.max_risk_per_trade`
+  - Check: all legs have `contracts > 0`
+  - Check: expiry in future
+  - Check: if options_chain available, strikes exist in chain
+  - Return list of validation errors (empty = valid)
+- **Test**: Parse valid JSON → success. Parse JSON missing "legs" → ValueError. Validate recommendation exceeding risk → returns error. Validate recommendation with unknown structure → returns error.
+
+### Task 9: Implement `OpusStrategyAdvisor._fallback_to_matrix()`
+- **File**: `ktrdr_options/strategy/opus_advisor.py`
+- **Method**: `_fallback_to_matrix(self, decision_input, reason) -> TradeRecommendation`
+- Call `self._fallback_matrix.select(decision_input)` → `StructureChoice`
+- Build `TradeRecommendation` from `StructureChoice`:
+  - Use `BlackScholesEngine` to compute strikes and prices from structure parameters
+  - Set `source = "matrix"`
+  - Set `reasoning = f"Opus fallback: {reason}. {matrix_reasoning}"`
+  - Set `warnings = ["opus_fallback"]`
+- **Test**: Call with reason="timeout" → verify TradeRecommendation has source="matrix" and warnings includes "opus_fallback".
+
+### Task 10: Implement `LuxOrchestrator.run_cycle()` — 10-step analysis flow
+- **File**: `ktrdr_options/orchestrator.py`
+- **Method**: `run_cycle(self) -> CycleResult`
+- 10-step flow per ARCHITECTURE.md Section 2.K:
+  1. Fetch ktrdr signal via `KtrdrSignalClient.predict()`
+  2. Fetch recent OHLCV for Kronos (from ktrdr data or yfinance)
+  3. Run `KronosVolClassifier.predict()` on recent OHLCV
+  4. Fetch IV data via `OptionsDataProvider.get_iv_data()`
+  5. Fetch options chain via `OptionsDataProvider.get_options_chain()` (paper mode)
+  6. Aggregate via `SignalAggregator.aggregate()`
+  7. Get recommendation via `OpusStrategyAdvisor.advise()`
+  8. Mark-to-market all open positions
+  9. Check exit conditions on all open positions, close if triggered
+  10. If recommendation.action == "OPEN" and risk budget available: log recommendation (no execution in M4)
+- Persist `signals` row to SQLite
+- Build and return `CycleResult`
+- Wrap entire flow in try/except — log errors, continue
+- **Test**: Mock all dependencies, run cycle → verify CycleResult has all fields. Verify signals table has new row. Verify errors are caught and logged.
+
+### Task 11: Implement `LuxOrchestrator.start()` — scheduler loop
+- **File**: `ktrdr_options/orchestrator.py`
+- **Method**: `start(self, interval_minutes: int = 60) -> None`
+- `asyncio` loop that runs `run_cycle()` every `interval_minutes`
+- Only run during market hours if `schedule.trading_hours_only == True`:
+  - Check current time against `market_open` and `market_close` in configured timezone
+- Set `self._running = True`; loop until `stop()` is called
+- **Test**: Start with interval_minutes=0 (immediate), verify cycle runs. Call stop(), verify loop exits.
+
+### Task 12: Implement `LuxOrchestrator._send_telegram_report()`
+- **File**: `ktrdr_options/orchestrator.py`
+- **Method**: `_send_telegram_report(self, cycle_result: CycleResult) -> None`
+- Format message based on notification type:
+  - **trade_opened**: "OPEN: {structure} {symbol} {strikes} exp {expiry} — max risk ${max_risk}"
+  - **trade_closed**: "CLOSED: {position_id} — {exit_reason} — PnL: ${pnl} ({pnl_pct}%)"
+  - **error**: "ERROR: {error_message}"
+  - **daily_summary**: aggregate stats: open positions, total PnL, portfolio Greeks
+- Send via Telegram Bot API: `POST https://api.telegram.org/bot{token}/sendMessage`
+- Use `httpx.AsyncClient` for non-blocking send
+- Graceful failure: if Telegram API unreachable, log warning and continue
+- **Test**: Mock Telegram API → verify message format. Mock Telegram failure → verify no exception raised.
+
+### Task 13: Wire SQLite live schema — `positions`, `trades`, `signals` tables
+- **File**: `ktrdr_options/persistence/schema.py`
+- Implement `create_live_schema()` (stubbed in M3):
+  - Create `positions` table per ARCHITECTURE.md Section 4
+  - Create `trades` table
+  - Create `signals` table
+  - Create `calibration` table (stub for M5)
+  - Create all indexes
+- Wire into `LuxOrchestrator.__init__()`: create/connect to SQLite database
+- Wire into `run_cycle()`: write `signals` row after each cycle
+- **Test**: Initialize orchestrator, verify all tables exist. Run cycle, verify signals row written with all fields populated.
+
+---
+
+## F. Acceptance Criteria
+
+### Unit Tests
+- [ ] `KtrdrSignalClient.predict()` returns valid `KtrdrSignal` from mock HTTP response
+- [ ] `KtrdrSignalClient.predict()` retries 3 times with exponential backoff on failure
+- [ ] `KtrdrSignalClient.predict()` raises `KtrdrStaleDataError` for stale data
+- [ ] `KtrdrSignalClient.health_check()` returns True/False appropriately
+- [ ] `OpusStrategyAdvisor.advise()` parses valid Opus response into `TradeRecommendation`
+- [ ] `OpusStrategyAdvisor.advise()` falls back to matrix on Opus failure (timeout, invalid JSON, validation error)
+- [ ] `OpusStrategyAdvisor._validate_recommendation()` catches risk limit violations and unknown structures
+- [ ] `OpusStrategyAdvisor._build_prompt()` includes all required context fields
+- [ ] `LuxOrchestrator.run_cycle()` completes all 10 steps with mocked dependencies
+- [ ] `LuxOrchestrator._send_telegram_report()` formats messages correctly
+- [ ] Telegram failure does not crash the cycle
+
+### Integration Tests
+- [ ] ktrdr API returns `probabilities` field after code change (requires running ktrdr server)
+- [ ] Full cycle with mock ktrdr API + mock Anthropic API → correct signals logged to SQLite
+- [ ] Matrix fallback produces valid `TradeRecommendation` when Opus is mocked to fail
+- [ ] SQLite `signals` table has a row for each completed cycle
+- [ ] SQLite `positions` table is updated on mark-to-market
+
+### Empirical Validation Gates
+- [ ] **Full analysis cycle completes in < 90 seconds** (including Opus call with mock or real API)
+- [ ] SQLite records are written correctly after each cycle
+- [ ] Telegram notification fires (with mock or real bot)
+- [ ] Fallback to matrix works when Opus is mocked to return errors
+
+### Performance Requirements
+- [ ] ktrdr signal fetch: < 5 seconds (localhost)
+- [ ] Kronos inference: < 2 seconds (CPU)
+- [ ] Opus 4.7 call: < 60 seconds (including extended thinking)
+- [ ] Total cycle time: < 90 seconds
+- [ ] SQLite write: < 100ms per row
+
+---
+
+## G. Estimated Effort
+
+**10 developer-days**
+
+| Task | Days |
+|------|------|
+| ktrdr API extension (Task 1) | 0.5 |
+| KtrdrSignalClient (Tasks 2-3) | 1.5 |
+| OptionsDataProvider — chain + IV (Tasks 4-5) | 1.0 |
+| OpusStrategyAdvisor — advise + prompt (Tasks 6-7) | 2.0 |
+| OpusStrategyAdvisor — parse + validate + fallback (Tasks 8-9) | 1.5 |
+| LuxOrchestrator — cycle + scheduler (Tasks 10-11) | 1.5 |
+| Telegram + SQLite wiring (Tasks 12-13) | 1.0 |
+| Integration testing | 1.0 |
+
+The Opus prompt engineering (Tasks 6-7) may require iteration — the prompt must reliably produce valid JSON with correct structure. Budget time for prompt refinement.
+
+---
+
+## H. Open Questions / Risks
+
+1. **Opus 4.7 prompt reliability**: Getting Opus to consistently return valid JSON matching the `TradeRecommendation` schema is the primary risk. The prompt must be explicit about the schema. Consider using tool use / function calling instead of free-form JSON generation if available in the API. `[VALIDATE EMPIRICALLY]`: Test prompt with 50+ diverse inputs and measure JSON parse success rate. Target: > 95%.
+
+2. **Opus 4.7 extended thinking latency**: Extended thinking can take 10-60 seconds depending on complexity. The 60-second timeout is generous but may not be enough for complex scenarios. Monitor actual latencies during testing. If consistently > 45s, consider disabling extended thinking or simplifying the prompt.
+
+3. **`[DECISION NEEDED]` ktrdr API extension**: The ~10 line change to add `probabilities` to the REST response is the recommended approach. Alternative: call ktrdr as a library from the orchestrator (bypasses REST, but tighter coupling). Karl's preference?
+
+4. **Telegram bot setup**: Assumes a Telegram bot is already configured with `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` environment variables. If not set up, the notification system should degrade gracefully (log-only mode).
+
+5. **OHLCV data for Kronos in live mode**: The orchestrator needs recent OHLCV bars to feed Kronos. In live mode, these must come from ktrdr's data layer or from yfinance. Need to decide: (a) call ktrdr's data API endpoint, (b) use yfinance directly, or (c) share ktrdr's local CSV cache. Option (c) is simplest if both services run on the same machine.
+
+6. **Options chain data quality**: yfinance options chain data can be delayed by 15 minutes and may have gaps. For paper trading analysis, this is acceptable. For live trading (M5), IBKR data is required.
+
+7. **Opus 4.7 prompt template**: The full prompt template must be included in this milestone document. See Task 7 for the complete system prompt and schema. The prompt should be version-controlled and configurable — prompt changes are a form of model tuning and should be trackable.
+
+### Opus 4.7 Prompt Template (Complete)
+
+**System Prompt**:
+```
+You are an expert options strategy advisor for an autonomous trading system. You receive structured market data including directional signals, volatility regime classification, and options chain data. Your task is to recommend a specific options trade or advise holding.
+
+## Allowed Structures
+- bull_put_spread: Sell OTM put + buy further OTM put (bullish, premium collection)
+- bear_call_spread: Sell OTM call + buy further OTM call (bearish, premium collection)
+- bull_call_spread: Buy ATM call + sell OTM call (bullish, defined risk)
+- bear_put_spread: Buy ATM put + sell OTM put (bearish, defined risk)
+- iron_condor: Sell OTM put + buy further OTM put + sell OTM call + buy further OTM call (neutral, premium collection)
+- long_call: Buy OTM call (bullish + vol expansion)
+- long_put: Buy OTM put (bearish + vol expansion)
+- long_straddle: Buy ATM call + ATM put (neutral direction, vol expansion)
+
+## Constraints
+- max_risk MUST NOT exceed the provided max_risk_per_trade
+- All strikes should be realistic given the underlying price
+- Expiry should be 14-45 DTE depending on structure
+- For credit spreads: short strike delta should be 0.16-0.30
+- For debit spreads: long strike delta should be 0.40-0.50
+- Respond ONLY with valid JSON matching the schema below — no other text
+
+## Response JSON Schema
+{
+  "action": "OPEN" or "HOLD",
+  "structure": "<one of the allowed structures>",
+  "legs": [
+    {
+      "action": "BUY" or "SELL",
+      "option_type": "CALL" or "PUT",
+      "strike": <float>,
+      "expiry": "<YYYY-MM-DD>",
+      "contracts": <int>
+    }
+  ],
+  "expected_credit": <float or null>,
+  "expected_debit": <float or null>,
+  "max_risk": <float, in dollars>,
+  "max_profit": <float, in dollars>,
+  "breakeven": <float or [float, float]>,
+  "exit_plan": {
+    "take_profit_pct": <float, e.g. 50.0>,
+    "stop_loss_pct": <float, e.g. 100.0>,
+    "time_exit_dte": <int, e.g. 7>
+  },
+  "reasoning": "<1-3 sentences explaining the trade logic>",
+  "confidence": "HIGH" or "MEDIUM" or "LOW",
+  "warnings": ["<any concerns>"]
+}
+
+If you believe no trade should be opened, respond with:
+{"action": "HOLD", "structure": "no_trade", "legs": [], "reasoning": "<why>", "confidence": "HIGH", "warnings": []}
+```
+
+**User Message** (rendered from DecisionInput):
+```
+Analyze the following market data and recommend an options trade:
+
+{decision_input.to_json()}
+
+The deterministic decision matrix suggests: {matrix_suggestion}
+Reasoning: {matrix_reasoning}
+
+Consider the matrix suggestion as a starting point. You may agree, modify strikes/expiry, adjust position size, or override entirely if you see a better opportunity or risk concern.
+```

--- a/docs/designs/autonomous-options-trading/milestones/MILESTONE_5.md
+++ b/docs/designs/autonomous-options-trading/milestones/MILESTONE_5.md
@@ -1,0 +1,291 @@
+# Milestone 5: IBKR Execution + Paper Trading + Calibration
+
+---
+
+## A. Objective
+
+Close the loop — connect the full analysis pipeline to Interactive Brokers via IBKR MCP for paper trade execution, run the system for 60+ trading days to collect statistically meaningful performance data, and validate that live performance tracks synthetic backtest results. Target: paper Sharpe > 0.40 over 60+ days with >= 30 trades. This milestone also implements the calibration system that monitors rolling accuracy and alerts on signal degradation.
+
+---
+
+## B. Go/No-Go Gate (from previous milestone)
+
+**Entry gate from M4**:
+- [ ] Full analysis cycle completes end-to-end in < 90 seconds
+- [ ] SQLite records (signals, positions) are written correctly each cycle
+- [ ] Telegram notification fires on trade events and errors
+- [ ] Matrix fallback works when Opus 4.7 is unavailable
+- [ ] `KtrdrSignalClient` successfully fetches signals from running ktrdr server
+- [ ] `OpusStrategyAdvisor` parses and validates Opus responses with > 95% success rate on diverse inputs
+
+**Critical pre-check before starting M5**:
+- [ ] **`[DECISION NEEDED]` IBKR MCP options capabilities validated** — Can the existing IBKR MCP integration:
+  - Request options contract details? (`reqContractDetails` with `SecType=OPT`)
+  - Place single-leg options orders?
+  - Place combo (BAG) orders for multi-leg spreads?
+  - If BAG orders unsupported: document the sequential-leg execution plan with slippage risk.
+
+---
+
+## C. Files to Create (proposed paths)
+
+| # | File Path | Purpose | Key Classes/Functions |
+|---|-----------|---------|----------------------|
+| 1 | `ktrdr-options/ktrdr_options/execution/__init__.py` | Execution subpackage init | Exports |
+| 2 | `ktrdr-options/ktrdr_options/execution/ibkr_executor.py` | IBKR MCP trade execution | `IBKRExecutor`, `OrderResult`, `IBKRExecutionError` |
+| 3 | `ktrdr-options/ktrdr_options/calibration/__init__.py` | Calibration subpackage init | Exports |
+| 4 | `ktrdr-options/ktrdr_options/calibration/monitor.py` | Rolling accuracy and calibration monitoring | `CalibrationMonitor`, `CalibrationReport` |
+| 5 | `ktrdr-options/ktrdr_options/calibration/alerts.py` | Degradation detection and Telegram alerts | `DegradationDetector`, `AlertLevel` |
+| 6 | `ktrdr-options/tests/test_ibkr_executor.py` | IBKR executor tests with mock MCP | `TestIBKRExecutor` |
+| 7 | `ktrdr-options/tests/test_calibration.py` | Calibration monitor tests | `TestCalibrationMonitor` |
+
+---
+
+## D. Files to Modify (in ktrdr-options repo)
+
+| # | File Path | Change | Why |
+|---|-----------|--------|-----|
+| 1 | `ktrdr_options/orchestrator.py` | Implement `_execute_trade()` with IBKR MCP call. Add paper/live mode toggle. Add approval gate for live trades. | Enables actual trade execution in paper and live modes. |
+| 2 | `ktrdr_options/data/options_data.py` | Implement `get_options_chain()` IBKR mode — fetch real chain data via IBKR MCP. | Replaces yfinance snapshot with real-time IBKR options chain for paper/live. |
+| 3 | `ktrdr_options/orchestrator.py` | Add daily calibration cycle: call `CalibrationMonitor` after each cycle, write to SQLite `calibration` table. | Enables rolling performance monitoring and degradation alerts. |
+| 4 | `ktrdr-options-config.yaml` | Add `options_data.mode: "paper"` toggle and IBKR connection config. | Switches between backtest/paper/live data sources. |
+
+---
+
+## E. Implementation Tasks
+
+### Task 1: Validate IBKR MCP capabilities for options
+- **Action**: Investigate and document the existing IBKR MCP deployment's capabilities
+- Specific questions to answer:
+  - Can it call `reqContractDetails` with `SecType=OPT` to get options chains?
+  - Can it call `placeOrder` with `SecType=OPT` for single-leg options orders?
+  - Can it call `placeOrder` with `SecType=BAG` for combo/spread orders?
+  - What is the order status flow? (Submitted → Filled, partial fills, rejections)
+  - Is there an `orderStatus` or equivalent callback for fill confirmation?
+- Document results in a short capability report
+- **If BAG orders unsupported**: Design sequential-leg execution:
+  1. Place each leg as separate order
+  2. Wait for fill confirmation between legs
+  3. Track partial fills and handle re-pricing between legs
+  4. Add slippage tracking: actual fill price vs theoretical price
+- **Test**: Place a single-leg paper options order on SPY via IBKR MCP. Verify fill confirmation is received.
+- `[DECISION NEEDED]`: Result of this investigation determines execution strategy for all subsequent tasks.
+
+### Task 2: Implement `IBKRExecutor` — IBKR MCP trade execution wrapper
+- **File**: `ktrdr_options/execution/ibkr_executor.py`
+- **Class**: `IBKRExecutor`
+- **Method**: `execute_spread(self, recommendation: TradeRecommendation, symbol: str) -> OrderResult`
+  - If BAG orders supported: submit single combo order with all legs
+  - If BAG orders NOT supported: submit legs sequentially with 2-second delay between legs
+  - Wait for fill confirmation (timeout: 30 seconds per leg)
+  - Return `OrderResult(order_id, fill_price, fill_time, status, slippage)`
+- **Method**: `execute_single_leg(self, leg: OptionsLeg, symbol: str) -> OrderResult`
+  - Submit single options order via IBKR MCP
+  - Map `OptionsLeg` to IBKR contract specification:
+    - `Symbol: symbol`
+    - `SecType: "OPT"`
+    - `Strike: leg.strike`
+    - `Right: "C" if CALL, "P" if PUT`
+    - `Expiry: leg.expiry` (YYYYMMDD format)
+    - `Exchange: "SMART"`
+    - `Currency: "USD"`
+    - `Action: "BUY" or "SELL"`
+    - `TotalQuantity: leg.contracts`
+    - `OrderType: "LMT"` with limit price from estimated_price + slippage margin
+  - **Test**: Mock IBKR MCP → verify correct contract specification. Mock fill → verify OrderResult fields.
+
+### Task 3: Implement `LuxOrchestrator._execute_trade()` — with approval gate
+- **File**: `ktrdr_options/orchestrator.py`
+- **Method**: `_execute_trade(self, recommendation, decision_input) -> str`
+- Flow:
+  1. **Paper mode** (`self._mode == "paper"`):
+     - Call `IBKRExecutor.execute_spread(recommendation, symbol)` directly
+     - Log execution result
+     - Return order status
+  2. **Live mode** (`self._mode == "live"`):
+     - Send Telegram approval request:
+       ```
+       TRADE APPROVAL REQUIRED
+       {structure} {symbol} {strikes} exp {expiry}
+       Max risk: ${max_risk}
+       Max profit: ${max_profit}
+       Source: {opus/matrix}
+       
+       Reply YES within 10 minutes to approve.
+       ```
+     - Wait for Karl's Telegram reply (poll or webhook, timeout: 10 minutes)
+     - If "YES": execute via `IBKRExecutor`
+     - If "NO" or timeout: log rejection, return "rejected"
+  3. Record execution in SQLite `trades` table
+- **Test**: Paper mode → verify IBKR executor called. Live mode + mock "YES" reply → verify execution. Live mode + timeout → verify rejection logged.
+
+### Task 4: Implement `OptionsDataProvider.get_options_chain()` in IBKR mode
+- **File**: `ktrdr_options/data/options_data.py`
+- **Method**: Extend `get_options_chain()` for `mode == "paper"` or `mode == "live"`:
+  - Call IBKR MCP `reqContractDetails` with `SecType=OPT`, `Symbol=symbol`
+  - Fetch available strikes and expiries
+  - Fetch bid/ask, IV, and Greeks for each contract (if provided by IBKR)
+  - Filter by DTE and delta range
+  - Map to `OptionsChain` with `OptionContract` list
+- Fall back to yfinance if IBKR is unreachable
+- **Test**: Mock IBKR MCP chain response → verify OptionsChain populated correctly. Mock IBKR failure → verify yfinance fallback.
+
+### Task 5: Implement paper trading mode toggle
+- **File**: `ktrdr-options-config.yaml` and `ktrdr_options/orchestrator.py`
+- Config: `options_data.mode: "paper"` enables:
+  - IBKR connection to paper port (7497 vs 7496 for live)
+  - Real options chain from IBKR paper
+  - Trade execution on IBKR paper
+  - No approval gate (auto-execute)
+- Verify `LuxOrchestrator.__init__()` reads mode from config
+- Verify mode propagates to `OptionsDataProvider`, `IBKRExecutor`
+- **Test**: Initialize with mode="paper" → verify IBKR port=7497. Initialize with mode="live" → verify port=7496.
+
+### Task 6: Implement `CalibrationMonitor` — rolling accuracy computation
+- **File**: `ktrdr_options/calibration/monitor.py`
+- **Class**: `CalibrationMonitor`
+- **Method**: `compute_calibration(self, symbol: str, window_days: int = 30) -> CalibrationReport`
+- From SQLite `trades` and `signals` tables, compute:
+  - **ktrdr accuracy**: rolling win rate of ktrdr directional signal (was the predicted direction correct?)
+  - **ktrdr signal distribution**: % BUY, SELL, HOLD over window (detect all-HOLD degeneration)
+  - **Kronos regime accuracy**: did the predicted vol regime match the realized outcome? (SELL_VOL correct if actual RV < IV at time of prediction)
+  - **System win rate**: % of closed options trades with positive PnL
+  - **Rolling Sharpe**: 30-day rolling Sharpe from equity curve
+  - **Structure performance**: win rate per structure type
+- Return `CalibrationReport` dataclass with all fields
+- Write row to SQLite `calibration` table
+- **Test**: Given 10 mock trades (7 wins, 3 losses), verify win_rate=0.70. Verify rolling Sharpe computed correctly.
+
+### Task 7: Implement `DegradationDetector` — alert on accuracy drops
+- **File**: `ktrdr_options/calibration/alerts.py`
+- **Class**: `DegradationDetector`
+- **Method**: `check(self, current_calibration: CalibrationReport, backtest_baseline: dict) -> list[tuple[AlertLevel, str]]`
+- Alert conditions:
+  1. ktrdr win rate drops > 20% from backtest baseline → `AlertLevel.WARNING`
+  2. System win rate drops below 40% → `AlertLevel.WARNING`
+  3. ktrdr HOLD percentage > 70% (degeneration) → `AlertLevel.CRITICAL`
+  4. Rolling Sharpe < 0 for 14+ consecutive days → `AlertLevel.CRITICAL`
+  5. Kronos regime accuracy < random (33%) → `AlertLevel.INFO` (regime may not be adding value)
+- Return list of (level, message) tuples
+- **CRITICAL alerts**: Pause new trade openings, continue monitoring/closing existing positions
+- **Test**: Mock calibration with 15% win rate drop → verify WARNING alert. Mock 75% HOLD rate → verify CRITICAL alert. Mock Sharpe = -0.5 for 14 days → verify CRITICAL.
+
+### Task 8: Wire calibration into `LuxOrchestrator`
+- **File**: `ktrdr_options/orchestrator.py`
+- After each cycle (or daily):
+  - Call `CalibrationMonitor.compute_calibration()`
+  - Call `DegradationDetector.check()`
+  - If any alerts: send Telegram notification with alert level and message
+  - If CRITICAL alert: set `self._pause_new_trades = True` (continue monitoring only)
+  - Write calibration row to SQLite
+- Add daily summary Telegram message (end of trading day):
+  - Open positions count and total PnL
+  - Today's trades (opened/closed)
+  - Rolling 30-day Sharpe
+  - Any active alerts
+- **Test**: Run cycle → verify calibration computed. Trigger CRITICAL alert → verify new trades paused. Verify daily summary message format.
+
+### Task 9: Run 60-day paper trading period
+- **Action**: Deploy and run the full system in paper mode for 60+ trading days
+- Setup:
+  1. Start ktrdr server with trained SPY model
+  2. Start `LuxOrchestrator` in paper mode: `python -m ktrdr_options.orchestrator --mode paper`
+  3. Configure 60-minute cycle interval during market hours
+  4. Monitor Telegram for trade notifications and alerts
+- During the period:
+  - Track: trades opened, trades closed, PnL per trade, exit reasons
+  - Monitor: calibration alerts, signal degradation, IBKR connectivity
+  - Intervene only on CRITICAL alerts — otherwise let the system run autonomously
+- **Acceptance**: 60+ trading days, >= 30 trades, all trades logged to SQLite
+- `[VALIDATE EMPIRICALLY]`: This is the live Sharpe > 0.40 gate.
+
+### Task 10: Write performance report — compare live vs backtest
+- **Action**: After 60-day paper period, generate comprehensive comparison report
+- Compare:
+  - Paper Sharpe vs synthetic backtest Sharpe
+  - Paper win rate vs backtest win rate
+  - Structure breakdown: which structures performed differently live vs backtest?
+  - Exit reason distribution: live vs backtest
+  - Signal distribution: did ktrdr/Kronos signal patterns change?
+  - Slippage analysis: how much did actual fills deviate from theoretical prices?
+  - Opus vs matrix: what % of trades used Opus, what % fell back to matrix?
+  - Calibration trends: any degradation over the 60-day period?
+- Flag significant discrepancies for investigation
+- **Test**: Report generates without error from SQLite data. All metrics present.
+
+---
+
+## F. Acceptance Criteria
+
+### Unit Tests
+- [ ] `IBKRExecutor.execute_spread()` correctly maps TradeRecommendation legs to IBKR contract specs
+- [ ] `IBKRExecutor.execute_single_leg()` handles fill confirmation and timeout
+- [ ] `IBKRExecutor` handles sequential leg execution when BAG orders unavailable
+- [ ] `LuxOrchestrator._execute_trade()` calls IBKR executor in paper mode
+- [ ] `LuxOrchestrator._execute_trade()` sends approval request and waits in live mode
+- [ ] `OptionsDataProvider.get_options_chain()` fetches real chain from IBKR MCP
+- [ ] `CalibrationMonitor.compute_calibration()` produces correct metrics from mock data
+- [ ] `DegradationDetector.check()` fires correct alerts for degradation scenarios
+- [ ] Paper mode uses IBKR port 7497, live mode uses 7496
+
+### Integration Tests
+- [ ] Paper trade execution: submit order → receive fill confirmation → record in SQLite
+- [ ] Options chain from IBKR: fetch → filter → verify contracts have realistic bid/ask
+- [ ] Full cycle in paper mode: signal → analysis → recommendation → execution → notification
+- [ ] Calibration cycle: compute → check alerts → write SQLite → send Telegram
+- [ ] Daily summary Telegram message fires at market close
+
+### Empirical Validation Gates
+- [ ] **`[VALIDATE EMPIRICALLY]`** Paper Sharpe > 0.40 over 60+ trading days
+- [ ] **`[VALIDATE EMPIRICALLY]`** >= 30 paper trades executed
+- [ ] System runs autonomously for 60+ days without CRITICAL unrecoverable failures
+- [ ] All trades have fill confirmation and PnL recorded
+- [ ] Calibration alerts fire correctly on simulated degradation
+
+### Performance Requirements
+- [ ] IBKR order submission to fill confirmation: < 30 seconds per leg
+- [ ] Full cycle with execution: < 120 seconds total
+- [ ] Calibration computation: < 5 seconds
+- [ ] System uptime during paper trading: > 95% (excludes scheduled downtime)
+
+---
+
+## G. Estimated Effort
+
+**8 developer-days** (excluding the 60-day paper trading period)
+
+| Task | Days |
+|------|------|
+| IBKR MCP capability validation (Task 1) | 1.0 |
+| IBKRExecutor implementation (Task 2) | 1.5 |
+| Orchestrator execution + approval gate (Task 3) | 1.0 |
+| IBKR options chain provider (Task 4) | 1.0 |
+| Paper mode toggle (Task 5) | 0.5 |
+| CalibrationMonitor (Task 6) | 1.0 |
+| DegradationDetector + wiring (Tasks 7-8) | 1.0 |
+| Performance report (Task 10) | 1.0 |
+
+The 60-day paper trading period (Task 9) runs in production and does not count as development effort — it is a validation period. During this time, the developer monitors for issues and makes hotfixes as needed.
+
+---
+
+## H. Open Questions / Risks
+
+1. **`[DECISION NEEDED]` IBKR MCP multi-leg support**: This is the critical unknown for M5. If the existing IBKR MCP does NOT support BAG orders, multi-leg spreads must be executed as sequential single-leg orders. This introduces:
+   - **Leg risk**: time between legs creates exposure (e.g., selling a put before buying the protective put)
+   - **Slippage risk**: prices may move between legs
+   - **Mitigation**: Execute protective leg (buy) first, then income leg (sell). Track slippage vs theoretical price.
+
+2. **IBKR paper account setup**: Karl must have an IBKR paper trading account configured. IBKR paper accounts mirror live market data with 15-minute delay (or real-time with market data subscription). `[DECISION NEEDED]`: Is IBKR paper already set up? Is IB Gateway or TWS running?
+
+3. **Fill quality**: Paper trading fills may be unrealistically good (instant fills at mid-price). Real fills will have slippage. The slippage analysis in the performance report (Task 10) is critical for assessing this gap.
+
+4. **Market data subscription**: IBKR options chain data requires a market data subscription. If Karl's IBKR account doesn't have options data, the chain will be empty. `[DECISION NEEDED]`: Verify IBKR market data subscription includes options.
+
+5. **60-day timeline**: 60 trading days = ~3 calendar months. This is a significant calendar commitment. If the system shows promise early (positive Sharpe after 30 days), consider a preliminary review to build confidence.
+
+6. **Signal degradation during paper period**: Market regime may shift during the 60-day period. The calibration system (Tasks 6-8) is designed to detect this, but corrective action (retraining models, adjusting thresholds) is outside M5 scope. Document degradation for post-M5 analysis.
+
+7. **Approval gate UX**: The Telegram approval gate (Task 3, live mode only) requires Karl to respond within 10 minutes. If Karl misses the window, the trade is skipped. This is by design for safety, but may result in missed opportunities. `[DECISION NEEDED]`: Is 10 minutes the right timeout? Should it be configurable?
+
+8. **`[VALIDATE EMPIRICALLY]`** Backtest-to-live performance gap: Expect 20-40% degradation from synthetic Sharpe (0.50) to paper Sharpe. If the gap is > 50%, investigate: is it fill quality (slippage), is it signal timing (stale data), is it regime shift (model degradation)?


### PR DESCRIPTION
## Summary

Complete design documentation for the ktrdr Autonomous Options Trading System — a new project that builds options trading on top of ktrdr's existing ML signals.

### What's included

- **DESIGN.md** — Full system design: ktrdr directional signal × Kronos vol regime → 8-cell decision matrix → options structure selection. Backtest-first approach with Opus 4.7 as live-trading advisor.
- **ARCHITECTURE.md** — Production-ready specs: 11 components with Python 3.12 type signatures, 6 SQLite tables, 4 sequence diagrams, 16-row error handling matrix.
- **IMPLEMENTATION_PLAN.md** — Master plan: 5 milestones, 63 tasks, 45 dev-days.
- **MILESTONE_1-5.md** — Detailed task files per milestone, each with file paths, acceptance criteria, and empirical gates.

### The 5 milestones

| Milestone | Effort | Gate |
|-----------|--------|------|
| M1: Kronos vol regime classifier | 8 days | AUC > 0.60 |
| M2: Black-Scholes engine + data infrastructure | 7 days | B-S validation |
| M3: Full synthetic backtest loop | 12 days | Sharpe > 0.50, 50+ trades |
| M4: Opus 4.7 advisor + LuxOrchestrator | 10 days | Cycle < 90s |
| M5: IBKR execution + 60-day paper trading | 8 days | Sharpe > 0.40 |

### ktrdr change required

One small change needed: extend `/api/v1/models/predict` to return `nn_probabilities` (~10 lines in `ktrdr/api/endpoints/models.py`). Backward-compatible optional field.

### Open decisions for Karl

1. Second symbol after SPY?
2. Historical options data budget ($0 B-S reconstruction / ~$200 OptionsDX / $1000+ CBOE)?
3. Approve the ~10-line ktrdr API extension?
4. Live trade approval gate via Telegram?
5. IBKR MCP multi-leg combo order support?
6. Max risk per trade (2% default)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)